### PR TITLE
Refactory and mask support

### DIFF
--- a/cases/src/adc_sbc_cases.rs
+++ b/cases/src/adc_sbc_cases.rs
@@ -2,17 +2,15 @@ use core::{arch::asm, convert::TryInto};
 use eint::{Eint, E256};
 use rvv_asm::rvv_asm;
 use rvv_testcases::runner::{
-    run_template_mvi, run_template_mvim, run_template_mvv, run_template_mvvm, run_template_mvx,
-    run_template_mvxm, run_template_vim, run_template_vvm, run_template_vxm, MaskType,
+    run_template_m_vi, run_template_m_vim, run_template_m_vv, run_template_m_vvm,
+    run_template_m_vx, run_template_m_vxm, run_template_v_vim, run_template_v_vvm,
+    run_template_v_vxm, MaskType,
 };
 
 // use ckb_std::syscalls::debug;
 // use rvv_testcases::log;
 
-const SEW_LIST: [u64; 2] = [64, 256];
-const LMUL_LIST: [i64; 5] = [-4, -2, 1, 4, 8];
-
-fn expected_op_adc_vvm(result: &mut [u8], lhs: &[u8], rhs: &[u8], mask: bool) {
+fn expected_op_adc_vvm(lhs: &[u8], rhs: &[u8], result: &mut [u8], mask: bool) {
     assert_eq!(lhs.len(), rhs.len());
     assert_eq!(rhs.len(), result.len());
     match lhs.len() {
@@ -45,16 +43,10 @@ fn test_vadc_vvm() {
         }
     }
 
-    run_template_vvm(
-        expected_op_adc_vvm,
-        rvv_op,
-        &SEW_LIST,
-        &LMUL_LIST,
-        "vadc.vvm",
-    )
+    run_template_v_vvm(expected_op_adc_vvm, rvv_op, "vadc.vvm")
 }
 
-fn expected_op_adc_vxm(result: &mut [u8], lhs: &[u8], x: u64, mask: bool) {
+fn expected_op_adc_vxm(lhs: &[u8], x: u64, result: &mut [u8], mask: bool) {
     match lhs.len() {
         8 => {
             let l = i64::from_le_bytes(lhs.try_into().unwrap());
@@ -84,17 +76,11 @@ fn test_vadc_vxm() {
             rvv_asm!("mv t0, {}", "vadc.vxm v24, v8, t0, v0", in (reg) x);
         }
     }
-    run_template_vxm(
-        expected_op_adc_vxm,
-        rvv_op,
-        &SEW_LIST,
-        &LMUL_LIST,
-        "vadc.vxm",
-    );
+    run_template_v_vxm(expected_op_adc_vxm, rvv_op, "vadc.vxm");
 }
 
-fn expected_op_adc_vim(result: &mut [u8], lhs: &[u8], x: i64, mask: bool) {
-    expected_op_adc_vxm(result, lhs, x as u64, mask);
+fn expected_op_adc_vim(lhs: &[u8], x: i64, result: &mut [u8], mask: bool) {
+    expected_op_adc_vxm(lhs, x as u64, result, mask);
 }
 fn test_vadc_vim() {
     fn rvv_op(_: &[u8], rhs: &[u8], _: MaskType) {
@@ -203,16 +189,10 @@ fn test_vadc_vim() {
             }
         }
     }
-    run_template_vim(
-        expected_op_adc_vim,
-        rvv_op,
-        &SEW_LIST,
-        &LMUL_LIST,
-        "vadc.vim",
-    );
+    run_template_v_vim(expected_op_adc_vim, rvv_op, "vadc.vim");
 }
 
-fn expected_op_madc_vvm(result: &mut bool, lhs: &[u8], rhs: &[u8], mask: bool) {
+fn expected_op_madc_vvm(lhs: &[u8], rhs: &[u8], result: &mut bool, mask: bool) {
     match lhs.len() {
         8 => {
             let l = u64::from_le_bytes(lhs.try_into().unwrap());
@@ -244,16 +224,10 @@ fn test_vmadc_vvm() {
         }
     }
 
-    run_template_mvvm(
-        expected_op_madc_vvm,
-        rvv_op,
-        &SEW_LIST,
-        &LMUL_LIST,
-        "vmadc.vvm",
-    )
+    run_template_m_vvm(expected_op_madc_vvm, rvv_op, "vmadc.vvm")
 }
 
-fn expected_op_madc_vxm(result: &mut bool, lhs: &[u8], x: u64, mask: bool) {
+fn expected_op_madc_vxm(lhs: &[u8], x: u64, result: &mut bool, mask: bool) {
     match lhs.len() {
         8 => {
             let l = u64::from_le_bytes(lhs.try_into().unwrap());
@@ -285,17 +259,11 @@ fn test_vmadc_vxm() {
         }
     }
 
-    run_template_mvxm(
-        expected_op_madc_vxm,
-        rvv_op,
-        &SEW_LIST,
-        &LMUL_LIST,
-        "vmadc.vxm",
-    )
+    run_template_m_vxm(expected_op_madc_vxm, rvv_op, "vmadc.vxm")
 }
 
-fn expected_op_madc_vim(result: &mut bool, lhs: &[u8], x: i64, mask: bool) {
-    expected_op_madc_vxm(result, lhs, x as u64, mask);
+fn expected_op_madc_vim(lhs: &[u8], x: i64, result: &mut bool, mask: bool) {
+    expected_op_madc_vxm(lhs, x as u64, result, mask);
 }
 fn test_vmadc_vim() {
     fn rvv_op(_: &[u8], rhs: &[u8], _: MaskType) {
@@ -404,18 +372,12 @@ fn test_vmadc_vim() {
             }
         }
     }
-    run_template_mvim(
-        expected_op_madc_vim,
-        rvv_op,
-        &SEW_LIST,
-        &LMUL_LIST,
-        "vadc.vim",
-    );
+    run_template_m_vim(expected_op_madc_vim, rvv_op, "vadc.vim");
 }
 
 fn test_vmadc_vv() {
-    fn exp_op(result: &mut bool, lhs: &[u8], rhs: &[u8]) {
-        expected_op_madc_vvm(result, lhs, rhs, false);
+    fn exp_op(lhs: &[u8], rhs: &[u8], result: &mut bool) {
+        expected_op_madc_vvm(lhs, rhs, result, false);
     }
     fn rvv_op(_: &[u8], _: &[u8], _: MaskType) {
         unsafe {
@@ -423,12 +385,12 @@ fn test_vmadc_vv() {
         }
     }
 
-    run_template_mvv(exp_op, rvv_op, &SEW_LIST, &LMUL_LIST, "vmadc.vv")
+    run_template_m_vv(exp_op, rvv_op, false, "vmadc.vv")
 }
 
 fn test_vmadc_vx() {
-    fn exp_op(result: &mut bool, lhs: &[u8], rhs: u64) {
-        expected_op_madc_vxm(result, lhs, rhs, false);
+    fn exp_op(lhs: &[u8], rhs: u64, result: &mut bool) {
+        expected_op_madc_vxm(lhs, rhs, result, false);
     }
     fn rvv_op(_: &[u8], rhs: &[u8], _: MaskType) {
         let x = u64::from_le_bytes(rhs.try_into().unwrap());
@@ -437,12 +399,12 @@ fn test_vmadc_vx() {
         }
     }
 
-    run_template_mvx(exp_op, rvv_op, &SEW_LIST, &LMUL_LIST, "vmadc.vx")
+    run_template_m_vx(exp_op, rvv_op, false, "vmadc.vx")
 }
 
 fn test_vmadc_vi() {
-    fn exp_op(result: &mut bool, lhs: &[u8], rhs: i64) {
-        expected_op_madc_vxm(result, lhs, rhs as u64, false);
+    fn exp_op(lhs: &[u8], rhs: i64, result: &mut bool) {
+        expected_op_madc_vxm(lhs, rhs as u64, result, false);
     }
     fn rvv_op(_: &[u8], rhs: &[u8], _: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
@@ -551,10 +513,10 @@ fn test_vmadc_vi() {
         }
     }
 
-    run_template_mvi(exp_op, rvv_op, &SEW_LIST, &LMUL_LIST, "vmadc.vi")
+    run_template_m_vi(exp_op, rvv_op, false, "vmadc.vi")
 }
 
-fn expected_op_sbc_vvm(result: &mut [u8], lhs: &[u8], rhs: &[u8], mask: bool) {
+fn expected_op_sbc_vvm(lhs: &[u8], rhs: &[u8], result: &mut [u8], mask: bool) {
     assert_eq!(lhs.len(), rhs.len());
     assert_eq!(rhs.len(), result.len());
     match lhs.len() {
@@ -587,16 +549,10 @@ fn test_vsbc_vvm() {
         }
     }
 
-    run_template_vvm(
-        expected_op_sbc_vvm,
-        rvv_op,
-        &SEW_LIST,
-        &LMUL_LIST,
-        "vsbc.vvm",
-    )
+    run_template_v_vvm(expected_op_sbc_vvm, rvv_op, "vsbc.vvm")
 }
 
-fn expected_op_sbc_vxm(result: &mut [u8], lhs: &[u8], x: u64, mask: bool) {
+fn expected_op_sbc_vxm(lhs: &[u8], x: u64, result: &mut [u8], mask: bool) {
     match lhs.len() {
         8 => {
             let l = i64::from_le_bytes(lhs.try_into().unwrap());
@@ -626,16 +582,10 @@ fn test_vsbc_vxm() {
             rvv_asm!("mv t0, {}", "vsbc.vxm v24, v8, t0, v0", in (reg) x);
         }
     }
-    run_template_vxm(
-        expected_op_sbc_vxm,
-        rvv_op,
-        &SEW_LIST,
-        &LMUL_LIST,
-        "vsbc.vxm",
-    );
+    run_template_v_vxm(expected_op_sbc_vxm, rvv_op, "vsbc.vxm");
 }
 
-fn expected_op_msbc_vvm(result: &mut bool, lhs: &[u8], rhs: &[u8], mask: bool) {
+fn expected_op_msbc_vvm(lhs: &[u8], rhs: &[u8], result: &mut bool, mask: bool) {
     match lhs.len() {
         8 => {
             let l = u64::from_le_bytes(lhs.try_into().unwrap());
@@ -667,16 +617,10 @@ fn test_vmsbc_vvm() {
         }
     }
 
-    run_template_mvvm(
-        expected_op_msbc_vvm,
-        rvv_op,
-        &SEW_LIST,
-        &LMUL_LIST,
-        "vmsbc.vvm",
-    )
+    run_template_m_vvm(expected_op_msbc_vvm, rvv_op, "vmsbc.vvm")
 }
 
-fn expected_op_msbc_vxm(result: &mut bool, lhs: &[u8], x: u64, mask: bool) {
+fn expected_op_msbc_vxm(lhs: &[u8], x: u64, result: &mut bool, mask: bool) {
     match lhs.len() {
         8 => {
             let l = u64::from_le_bytes(lhs.try_into().unwrap());
@@ -708,18 +652,12 @@ fn test_vmsbc_vxm() {
         }
     }
 
-    run_template_mvxm(
-        expected_op_msbc_vxm,
-        rvv_op,
-        &SEW_LIST,
-        &LMUL_LIST,
-        "vmsbc.vxm",
-    )
+    run_template_m_vxm(expected_op_msbc_vxm, rvv_op, "vmsbc.vxm")
 }
 
 fn test_vmsbc_vv() {
-    fn exp_op(result: &mut bool, lhs: &[u8], rhs: &[u8]) {
-        expected_op_msbc_vvm(result, lhs, rhs, false);
+    fn exp_op(lhs: &[u8], rhs: &[u8], result: &mut bool) {
+        expected_op_msbc_vvm(lhs, rhs, result, false);
     }
     fn rvv_op(_: &[u8], _: &[u8], _: MaskType) {
         unsafe {
@@ -727,12 +665,12 @@ fn test_vmsbc_vv() {
         }
     }
 
-    run_template_mvv(exp_op, rvv_op, &SEW_LIST, &LMUL_LIST, "vmsbc.vv")
+    run_template_m_vv(exp_op, rvv_op, false, "vmsbc.vv")
 }
 
 fn test_vmsbc_vx() {
-    fn exp_op(result: &mut bool, lhs: &[u8], rhs: u64) {
-        expected_op_msbc_vxm(result, lhs, rhs, false);
+    fn exp_op(lhs: &[u8], rhs: u64, result: &mut bool) {
+        expected_op_msbc_vxm(lhs, rhs, result, false);
     }
     fn rvv_op(_: &[u8], rhs: &[u8], _: MaskType) {
         let x = u64::from_le_bytes(rhs.try_into().unwrap());
@@ -741,7 +679,7 @@ fn test_vmsbc_vx() {
         }
     }
 
-    run_template_mvx(exp_op, rvv_op, &SEW_LIST, &LMUL_LIST, "vmsbc.vx")
+    run_template_m_vx(exp_op, rvv_op, false, "vmsbc.vx")
 }
 
 pub fn test_adc_sbc() {

--- a/cases/src/adc_sbc_cases.rs
+++ b/cases/src/adc_sbc_cases.rs
@@ -372,7 +372,7 @@ fn test_vmadc_vim() {
             }
         }
     }
-    run_template_m_vim(expected_op_madc_vim, rvv_op, "vadc.vim");
+    run_template_m_vim(expected_op_madc_vim, rvv_op, "vmadc.vim");
 }
 
 fn test_vmadc_vv() {

--- a/cases/src/integer_extension_cases.rs
+++ b/cases/src/integer_extension_cases.rs
@@ -1,11 +1,9 @@
-use alloc::boxed::Box;
 use core::{arch::asm, convert::TryInto};
 use eint::{Eint, E128, E256};
 use rvv_asm::rvv_asm;
 use rvv_testcases::{
-    intrinsic::vop_nv,
-    misc::{avl_iterator, conver_to_i256},
-    runner::{run_vop_vv, ExpectedOp, WideningCategory},
+    misc::conver_to_i256,
+    runner::{run_template_v_n, MaskType},
 };
 
 // use ckb_std::syscalls::debug;
@@ -27,30 +25,21 @@ fn expected_op_vzext_vf2(lhs: &[u8], _: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vzext_vf2(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_nv(
-            lhs,
-            rhs,
-            result,
-            sew,
-            avl,
-            lmul,
-            || unsafe {
-                rvv_asm!("vzext.vf2 v24, v8");
-            },
-            WideningCategory::NarrowVs2(2),
-        );
+fn test_vzext_vf2() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vzext.vf2 v24, v8, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vzext.vf2 v24, v8");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_vzext_vf2)),
-        op,
-        WideningCategory::NarrowVs2(2),
-        "vzext.vf2",
-    );
+    run_template_v_n(expected_op_vzext_vf2, op, 2, true, "vzext.vf2");
 }
 
 fn expected_op_vsext_vf2(lhs: &[u8], _: &[u8], result: &mut [u8]) {
@@ -69,30 +58,21 @@ fn expected_op_vsext_vf2(lhs: &[u8], _: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vsext_vf2(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_nv(
-            lhs,
-            rhs,
-            result,
-            sew,
-            avl,
-            lmul,
-            || unsafe {
-                rvv_asm!("vsext.vf2 v24, v8");
-            },
-            WideningCategory::NarrowVs2(2),
-        );
+fn test_vsext_vf2() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vsext.vf2 v24, v8, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vsext.vf2 v24, v8");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_vsext_vf2)),
-        op,
-        WideningCategory::NarrowVs2(2),
-        "vsext.vf2",
-    );
+    run_template_v_n(expected_op_vsext_vf2, op, 2, true, "vsext.vf2");
 }
 
 fn expected_op_vzext_vf4(lhs: &[u8], _: &[u8], result: &mut [u8]) {
@@ -111,30 +91,21 @@ fn expected_op_vzext_vf4(lhs: &[u8], _: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vzext_vf4(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_nv(
-            lhs,
-            rhs,
-            result,
-            sew,
-            avl,
-            lmul,
-            || unsafe {
-                rvv_asm!("vzext.vf4 v24, v8");
-            },
-            WideningCategory::NarrowVs2(4),
-        );
+fn test_vzext_vf4() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vzext.vf4 v24, v8, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vzext.vf4 v24, v8");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_vzext_vf4)),
-        op,
-        WideningCategory::NarrowVs2(4),
-        "vzext.vf4",
-    );
+    run_template_v_n(expected_op_vzext_vf4, op, 4, true, "vzext.vf4");
 }
 
 fn expected_op_vsext_vf4(lhs: &[u8], _: &[u8], result: &mut [u8]) {
@@ -153,30 +124,21 @@ fn expected_op_vsext_vf4(lhs: &[u8], _: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vsext_vf4(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_nv(
-            lhs,
-            rhs,
-            result,
-            sew,
-            avl,
-            lmul,
-            || unsafe {
-                rvv_asm!("vsext.vf4 v24, v8");
-            },
-            WideningCategory::NarrowVs2(4),
-        );
+fn test_vsext_vf4() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vsext.vf4 v24, v8, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vsext.vf4 v24, v8");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_vsext_vf4)),
-        op,
-        WideningCategory::NarrowVs2(4),
-        "vsext.vf4",
-    );
+    run_template_v_n(expected_op_vsext_vf4, op, 4, true, "vsext.vf4");
 }
 
 fn expected_op_vzext_vf8(lhs: &[u8], _: &[u8], result: &mut [u8]) {
@@ -194,33 +156,21 @@ fn expected_op_vzext_vf8(lhs: &[u8], _: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vzext_vf8(sew: u64, lmul: i64, avl: u64) {
-    if lmul <= -2 {
-        return;
+fn test_vzext_vf8() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vzext.vf8 v24, v8, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vzext.vf8 v24, v8");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_nv(
-            lhs,
-            rhs,
-            result,
-            sew,
-            avl,
-            lmul,
-            || unsafe {
-                rvv_asm!("vzext.vf8 v24, v8");
-            },
-            WideningCategory::NarrowVs2(8),
-        );
-    }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_vzext_vf8)),
-        op,
-        WideningCategory::NarrowVs2(8),
-        "vzext.vf8",
-    );
+    run_template_v_n(expected_op_vzext_vf8, op, 8, true, "vzext.vf8");
 }
 
 fn expected_op_vsext_vf8(lhs: &[u8], _: &[u8], result: &mut [u8]) {
@@ -228,7 +178,7 @@ fn expected_op_vsext_vf8(lhs: &[u8], _: &[u8], result: &mut [u8]) {
 
     match result.len() {
         8 => {
-            let l = lhs[0] as i64;
+            let l = lhs[0] as i8 as i64;
             result.copy_from_slice(&l.to_le_bytes());
         }
         32 => {
@@ -239,46 +189,30 @@ fn expected_op_vsext_vf8(lhs: &[u8], _: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vsext_vf8(sew: u64, lmul: i64, avl: u64) {
-    if lmul <= -2 {
-        return;
-    }
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_nv(
-            lhs,
-            rhs,
-            result,
-            sew,
-            avl,
-            lmul,
-            || unsafe {
-                rvv_asm!("vsext.vf8 v24, v8");
-            },
-            WideningCategory::NarrowVs2(8),
-        );
-    }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_vsext_vf8)),
-        op,
-        WideningCategory::NarrowVs2(8),
-        "vsext.vf8",
-    );
-}
-
-pub fn test_integer_extension() {
-    for sew in [64, 256] {
-        for lmul in [-2, 1, 4, 8] {
-            for avl in avl_iterator(sew, 4) {
-                test_vzext_vf2(sew, lmul, avl);
-                test_vsext_vf2(sew, lmul, avl);
-                test_vzext_vf4(sew, lmul, avl);
-                test_vsext_vf4(sew, lmul, avl);
-                test_vzext_vf8(sew, lmul, avl);
-                test_vsext_vf8(sew, lmul, avl);
+fn test_vsext_vf8() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vsext.vf8 v24, v8, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vsext.vf8 v24, v8");
+                }
+                _ => panic!("Abort"),
             }
         }
     }
+    run_template_v_n(expected_op_vsext_vf8, op, 8, true, "vsext.vf8");
+}
+
+pub fn test_integer_extension() {
+    test_vzext_vf2();
+    test_vsext_vf2();
+
+    test_vzext_vf4();
+    test_vsext_vf4();
+
+    test_vzext_vf8();
+    test_vsext_vf8();
 }

--- a/cases/src/integer_merge_cases.rs
+++ b/cases/src/integer_merge_cases.rs
@@ -1,10 +1,10 @@
 use core::{arch::asm, convert::TryInto};
 use eint::{Eint, E256};
 use rvv_asm::rvv_asm;
-use rvv_testcases::runner::{run_template_vim, run_template_vvm, run_template_vxm, MaskType};
+use rvv_testcases::runner::{run_template_v_vim, run_template_v_vvm, run_template_v_vxm, MaskType};
 
 fn test_vmerge_vvm() {
-    fn exp_op(result: &mut [u8], lhs: &[u8], rhs: &[u8], mask: bool) {
+    fn exp_op(lhs: &[u8], rhs: &[u8], result: &mut [u8], mask: bool) {
         if mask {
             result.copy_from_slice(rhs);
         } else {
@@ -17,11 +17,11 @@ fn test_vmerge_vvm() {
         }
     }
 
-    run_template_vvm(exp_op, op, &[64, 256], &[-8, -2, 1, 4, 8], "vmerge.vvm");
+    run_template_v_vvm(exp_op, op, "vmerge.vvm");
 }
 
 fn test_vmerge_vxm() {
-    fn exp_op(result: &mut [u8], lhs: &[u8], x: u64, mask: bool) {
+    fn exp_op(lhs: &[u8], x: u64, result: &mut [u8], mask: bool) {
         if mask {
             match result.len() {
                 8 => result.copy_from_slice(&x.to_le_bytes()),
@@ -39,11 +39,11 @@ fn test_vmerge_vxm() {
         }
     }
 
-    run_template_vxm(exp_op, op, &[64, 256], &[-8, -2, 1, 4, 8], "vmerge.vxm");
+    run_template_v_vxm(exp_op, op, "vmerge.vxm");
 }
 
 fn test_vmerge_vim() {
-    fn exp_op(result: &mut [u8], lhs: &[u8], x: i64, mask: bool) {
+    fn exp_op(lhs: &[u8], x: i64, result: &mut [u8], mask: bool) {
         if mask {
             match result.len() {
                 8 => result.copy_from_slice(&x.to_le_bytes()),
@@ -161,7 +161,7 @@ fn test_vmerge_vim() {
         }
     }
 
-    run_template_vim(exp_op, op, &[64, 256], &[-8, -2, 1, 4, 8], "vmerge.vim");
+    run_template_v_vim(exp_op, op, "vmerge.vim");
 }
 
 pub fn test_integer_merge() {

--- a/cases/src/integer_move_cases.rs
+++ b/cases/src/integer_move_cases.rs
@@ -171,7 +171,7 @@ fn test_vmv_v_i() {
         }
     }
 
-    run_template_v_vi(expected_op, op, true, "vmv.v.i");
+    run_template_v_vi(expected_op, op, false, true, "vmv.v.i");
 }
 
 fn test_vmv1r_v_v() {

--- a/cases/src/integer_move_cases.rs
+++ b/cases/src/integer_move_cases.rs
@@ -6,14 +6,14 @@ use rvv_asm::rvv_asm;
 use rvv_testcases::{
     misc::VLEN,
     rng::BestNumberRng,
-    runner::{run_template_vi, run_template_vv, run_template_vx, MaskType},
+    runner::{run_template_v_vi, run_template_v_vv, run_template_v_vx, MaskType},
 };
 
 use ckb_std::syscalls::debug;
 use rvv_testcases::log;
 
 fn test_vmv_v_v() {
-    fn expected_op(result: &mut [u8], _: &[u8], rhs: &[u8]) {
+    fn expected_op(_: &[u8], rhs: &[u8], result: &mut [u8]) {
         assert!(rhs.len() == result.len());
         result.copy_from_slice(rhs);
     }
@@ -23,18 +23,11 @@ fn test_vmv_v_v() {
         }
     }
 
-    run_template_vv(
-        expected_op,
-        op,
-        &[64, 256],
-        &[-8, -2, 1, 4, 8],
-        false,
-        "vmv.v.v",
-    );
+    run_template_v_vv(expected_op, op, false, "vmv.v.v");
 }
 
 fn test_vmv_v_x() {
-    fn expected_op(result: &mut [u8], _: &[u8], x: u64) {
+    fn expected_op(_: &[u8], x: u64, result: &mut [u8]) {
         match result.len() {
             8 => {
                 result.copy_from_slice(&x.to_le_bytes());
@@ -54,18 +47,11 @@ fn test_vmv_v_x() {
         }
     }
 
-    run_template_vx(
-        expected_op,
-        op,
-        &[64, 256],
-        &[-8, -2, 1, 4, 8],
-        false,
-        "vmv.v.x",
-    );
+    run_template_v_vx(expected_op, op, false, "vmv.v.x");
 }
 
 fn test_vmv_v_i() {
-    fn expected_op(result: &mut [u8], _: &[u8], x: i64) {
+    fn expected_op(_: &[u8], x: i64, result: &mut [u8]) {
         match result.len() {
             8 => {
                 result.copy_from_slice(&x.to_le_bytes());
@@ -185,18 +171,11 @@ fn test_vmv_v_i() {
         }
     }
 
-    run_template_vi(
-        expected_op,
-        op,
-        &[64, 256],
-        &[-8, -2, 1, 4, 8],
-        true,
-        "vmv.v.i",
-    );
+    run_template_v_vi(expected_op, op, true, "vmv.v.i");
 }
 
 fn test_vmv1r_v_v() {
-    fn expected_op(result: &mut [u8], _: &[u8], rhs: &[u8]) {
+    fn expected_op(_: &[u8], rhs: &[u8], result: &mut [u8]) {
         assert!(rhs.len() == result.len());
         result.copy_from_slice(rhs);
     }
@@ -206,14 +185,7 @@ fn test_vmv1r_v_v() {
         }
     }
 
-    run_template_vv(
-        expected_op,
-        op,
-        &[64, 256],
-        &[-8, -2, 1, 4, 8],
-        false,
-        "vmv.v.v",
-    );
+    run_template_v_vv(expected_op, op, false, "vmv.v.v");
 }
 
 fn test_vmv2r_v_v() {

--- a/cases/src/main.rs
+++ b/cases/src/main.rs
@@ -77,7 +77,7 @@ fn program_entry(argc: u64, argv: *const *const u8) -> i8 {
         }
     }
     test_case!(vsetvl_cases::test_vsetvl, test_pattern);
-    
+
     test_case!(misc_cases::test_add, test_pattern);
     test_case!(misc_cases::test_add_array, test_pattern);
     test_case!(vop_vv_cases::test_vop_vv, test_pattern);
@@ -117,35 +117,7 @@ fn program_entry(argc: u64, argv: *const *const u8) -> i8 {
     );
 
     test_case!(
-        single_width_integer_reduction_cases::test_vredop_vv,
-        test_pattern
-    );
-    test_case!(
-        single_width_integer_reduction_cases::test_vredop_and_vv,
-        test_pattern
-    );
-    test_case!(
-        single_width_integer_reduction_cases::test_vredop_or_vv,
-        test_pattern
-    );
-    test_case!(
-        single_width_integer_reduction_cases::test_vredop_xor_vv,
-        test_pattern
-    );
-    test_case!(
-        single_width_integer_reduction_cases::test_vredop_minu_vv,
-        test_pattern
-    );
-    test_case!(
-        single_width_integer_reduction_cases::test_vredop_min_vv,
-        test_pattern
-    );
-    test_case!(
-        single_width_integer_reduction_cases::test_vredop_maxu_vv,
-        test_pattern
-    );
-    test_case!(
-        single_width_integer_reduction_cases::test_vredop_max_vv,
+        single_width_integer_reduction_cases::test_vred_op,
         test_pattern
     );
     test_case!(
@@ -190,15 +162,7 @@ fn program_entry(argc: u64, argv: *const *const u8) -> i8 {
     test_case!(vector_compress_cases::test_vector_compress, test_pattern);
     test_case!(vector_slide_cases::test_vector_slide_up, test_pattern);
     test_case!(vector_slide_cases::test_vector_slide_down, test_pattern);
-    test_case!(vector_register_gather_cases::test_vrgather_vv, test_pattern);
-    test_case!(
-        vector_register_gather_cases::test_vrgatherei16_vv,
-        test_pattern
-    );
-    test_case!(
-        vector_register_gather_cases::test_vrgatherer_vx,
-        test_pattern
-    );
+    test_case!(vector_register_gather_cases::test_vrgatherer, test_pattern);
     test_case!(
         single_width_scaling_shift::test_single_with_scaling_shift,
         test_pattern

--- a/cases/src/mask_register_logical_cases.rs
+++ b/cases/src/mask_register_logical_cases.rs
@@ -1,225 +1,112 @@
-use alloc::boxed::Box;
-use alloc::vec::Vec;
-use core::iter::zip;
-use core::{arch::asm, ops::Not};
+use core::arch::asm;
 use rvv_asm::rvv_asm;
-use rvv_testcases::{
-    intrinsic::vop_vv,
-    runner::{run_vmop_mm, ExpectedOp},
-};
+use rvv_testcases::runner::{run_template_m_mm, MaskType};
 
-fn expected_op_and(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
-    assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
-    let mut res = Vec::new();
-    for (l, r) in zip(lhs, rhs) {
-        res.push(l & r);
+fn test_vmand_mm() {
+    fn expected_op(lhs: bool, rhs: bool, result: &mut bool) {
+        *result = lhs & rhs;
     }
-    result.copy_from_slice(res.as_slice());
-}
-
-fn test_vmand_mm(sew: u64) {
-    fn and(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
+    fn op(_: &[u8], _: &[u8], _: MaskType) {
+        unsafe {
             rvv_asm!("vmand.mm v24, v8, v16");
-        });
+        }
     }
-    // vm<op>.mm instructions can only operate on whole V register.
-    run_vmop_mm(
-        sew,
-        1,
-        256,
-        ExpectedOp::Normal(Box::new(expected_op_and)),
-        and,
-        "vmand.mm",
-    );
+    run_template_m_mm(expected_op, op, false, "vmand.mm");
 }
 
-fn expected_op_or(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
-    assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
-    let mut res = Vec::new();
-    for (l, r) in zip(lhs, rhs) {
-        res.push(l | r);
+fn test_vmor_mm() {
+    fn expected_op(lhs: bool, rhs: bool, result: &mut bool) {
+        *result = lhs | rhs;
     }
-    result.copy_from_slice(res.as_slice());
-}
-
-fn test_vmor_mm(sew: u64) {
-    fn or(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
+    fn op(_: &[u8], _: &[u8], _: MaskType) {
+        unsafe {
             rvv_asm!("vmor.mm v24, v8, v16");
-        });
+        }
     }
-    run_vmop_mm(
-        sew,
-        1,
-        256,
-        ExpectedOp::Normal(Box::new(expected_op_or)),
-        or,
-        "vmor.mm",
-    );
+    run_template_m_mm(expected_op, op, false, "vmor.mm");
 }
 
-fn expected_op_nor(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
-    assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
-    let mut res = Vec::new();
-    for (l, r) in zip(lhs, rhs) {
-        res.push((l | r).not());
+fn test_vmnor_mm() {
+    fn expected_op(lhs: bool, rhs: bool, result: &mut bool) {
+        *result = !(lhs | rhs);
     }
-    result.copy_from_slice(res.as_slice());
-}
-
-fn test_vmnor_mm(sew: u64) {
-    fn or(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
+    fn op(_: &[u8], _: &[u8], _: MaskType) {
+        unsafe {
             rvv_asm!("vmnor.mm v24, v8, v16");
-        });
+        }
     }
-    run_vmop_mm(
-        sew,
-        1,
-        256,
-        ExpectedOp::Normal(Box::new(expected_op_nor)),
-        or,
-        "vmnor.mm",
-    );
+    run_template_m_mm(expected_op, op, false, "vmnor.mm");
 }
 
-fn expected_op_orn(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
-    assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
-    let mut res = Vec::new();
-    for (l, r) in zip(lhs, rhs) {
-        res.push(l | r.not());
+fn test_vmorn_mm() {
+    fn expected_op(lhs: bool, rhs: bool, result: &mut bool) {
+        *result = lhs | !rhs;
     }
-    result.copy_from_slice(res.as_slice());
-}
-
-fn test_vmorn_mm(sew: u64) {
-    fn or(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
+    fn op(_: &[u8], _: &[u8], _: MaskType) {
+        unsafe {
             rvv_asm!("vmornot.mm v24, v8, v16");
-        });
+        }
     }
-    run_vmop_mm(
-        sew,
-        1,
-        256,
-        ExpectedOp::Normal(Box::new(expected_op_orn)),
-        or,
-        "vmornot.mm",
-    );
+    run_template_m_mm(expected_op, op, false, "vmornot.mm");
 }
 
-fn expected_op_nand(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
-    assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
-    let mut res = Vec::new();
-    for (l, r) in zip(lhs, rhs) {
-        res.push((l & r).not());
+fn test_vmnand_mm() {
+    fn expected_op(lhs: bool, rhs: bool, result: &mut bool) {
+        *result = !(lhs & rhs);
     }
-    result.copy_from_slice(res.as_slice());
-}
-
-fn test_vmnand_mm(sew: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
+    fn op(_: &[u8], _: &[u8], _: MaskType) {
+        unsafe {
             rvv_asm!("vmnand.mm v24, v8, v16");
-        });
+        }
     }
-    run_vmop_mm(
-        sew,
-        1,
-        256,
-        ExpectedOp::Normal(Box::new(expected_op_nand)),
-        op,
-        "vmnand.mm",
-    );
+    run_template_m_mm(expected_op, op, false, "vmnand.mm");
 }
 
-fn expected_op_andn(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
-    assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
-    let mut res = Vec::new();
-    for (l, r) in zip(lhs, rhs) {
-        res.push(l & r.not());
+fn test_vmandn_mm() {
+    fn expected_op(lhs: bool, rhs: bool, result: &mut bool) {
+        *result = lhs & !rhs;
     }
-    result.copy_from_slice(res.as_slice());
-}
-
-fn test_vmandn_mm(sew: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
+    fn op(_: &[u8], _: &[u8], _: MaskType) {
+        unsafe {
             rvv_asm!("vmandnot.mm v24, v8, v16");
-        });
+        }
     }
-    run_vmop_mm(
-        sew,
-        1,
-        256,
-        ExpectedOp::Normal(Box::new(expected_op_andn)),
-        op,
-        "vmandnot.mm",
-    );
+    run_template_m_mm(expected_op, op, false, "vmandnot.mm");
 }
 
-fn expected_op_xor(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
-    assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
-    let mut res = Vec::new();
-    for (l, r) in zip(lhs, rhs) {
-        res.push(l ^ r);
+fn test_vmxor_mm() {
+    fn expected_op(lhs: bool, rhs: bool, result: &mut bool) {
+        *result = lhs ^ rhs;
     }
-    result.copy_from_slice(res.as_slice());
-}
-
-fn test_vmxor_mm(sew: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
+    fn op(_: &[u8], _: &[u8], _: MaskType) {
+        unsafe {
             rvv_asm!("vmxor.mm v24, v8, v16");
-        });
+        }
     }
-    run_vmop_mm(
-        sew,
-        1,
-        256,
-        ExpectedOp::Normal(Box::new(expected_op_xor)),
-        op,
-        "vmxor.mm",
-    );
+    run_template_m_mm(expected_op, op, false, "vmxor.mm");
 }
 
-fn expected_op_xnor(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
-    assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
-    let mut res = Vec::new();
-    for (l, r) in zip(lhs, rhs) {
-        res.push((l ^ r).not());
+fn test_vmxnor_mm() {
+    fn expected_op(lhs: bool, rhs: bool, result: &mut bool) {
+        *result = !(lhs ^ rhs);
     }
-    result.copy_from_slice(res.as_slice());
-}
-
-fn test_vmxnor_mm(sew: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
+    fn op(_: &[u8], _: &[u8], _: MaskType) {
+        unsafe {
             rvv_asm!("vmxnor.mm v24, v8, v16");
-        });
+        }
     }
-    run_vmop_mm(
-        sew,
-        1,
-        256,
-        ExpectedOp::Normal(Box::new(expected_op_xnor)),
-        op,
-        "vmxnor.mm",
-    );
+    run_template_m_mm(expected_op, op, false, "vmxnor.mm");
 }
 
 pub fn test_mask_register_logical() {
-    let sew = 8u64;
+    test_vmand_mm();
+    test_vmnand_mm();
+    test_vmandn_mm();
 
-    test_vmand_mm(sew);
-    test_vmnand_mm(sew);
-    test_vmandn_mm(sew);
+    test_vmor_mm();
+    test_vmnor_mm();
+    test_vmorn_mm();
 
-    test_vmor_mm(sew);
-    test_vmnor_mm(sew);
-    test_vmorn_mm(sew);
-
-    test_vmxor_mm(sew);
-    test_vmxnor_mm(sew);
+    test_vmxor_mm();
+    test_vmxnor_mm();
 }

--- a/cases/src/misc.rs
+++ b/cases/src/misc.rs
@@ -114,16 +114,6 @@ macro_rules! log {
 }
 
 #[macro_export]
-macro_rules! dbg_log {
-    ($fmt:literal) => {
-        //debug(alloc::format!($fmt));
-    };
-    ($fmt:literal, $($args:expr),+) => {
-        //debug(alloc::format!($fmt, $($args), +));
-    };
-}
-
-#[macro_export]
 macro_rules! test_case {
     ($fun:path, $test_pattern:ident) => {{
         let fun_name = stringify!($fun);
@@ -135,12 +125,24 @@ macro_rules! test_case {
     }};
 }
 
-pub fn avl_iterator(sew: u64, target_lmul: i64) -> Vec<u64> {
-    if target_lmul > 0 {
-        let avl = target_lmul as u64 * VLEN as u64 / sew as u64;
-        vec![avl - 1, avl, avl + 1]
+pub fn avl_iterator(sew: u64, lmul: i64, _: i64) -> Vec<u64> {
+    let lmul = match lmul {
+        -8 => 0.125,
+        -4 => 0.25,
+        -2 => 0.5,
+        1 => 1.0,
+        2 => 2.0,
+        4 => 4.0,
+        8 => 8.0,
+        _ => panic!("Abort"),
+    };
+
+    let ret = VLEN as f64 / sew as f64 * lmul;
+    if ret <= 1.0 {
+        Vec::<u64>::new()
     } else {
-        panic!("TODO")
+        let ret = ret as u64;
+        vec![ret - 1, ret + 1]
     }
 }
 

--- a/cases/src/misc.rs
+++ b/cases/src/misc.rs
@@ -114,6 +114,16 @@ macro_rules! log {
 }
 
 #[macro_export]
+macro_rules! dbg_log {
+    ($fmt:literal) => {
+        //debug(alloc::format!($fmt));
+    };
+    ($fmt:literal, $($args:expr),+) => {
+        //debug(alloc::format!($fmt, $($args), +));
+    };
+}
+
+#[macro_export]
 macro_rules! test_case {
     ($fun:path, $test_pattern:ident) => {{
         let fun_name = stringify!($fun);
@@ -375,3 +385,13 @@ macro_rules! conver_with_single {
 
 conver_with_single!(conver_to_i512, E512, E256);
 conver_with_single!(conver_to_i256, E256, E128);
+
+#[inline]
+pub fn to_u64(d: &[u8]) -> u64 {
+    u64::from_le_bytes(d.try_into().unwrap())
+}
+
+#[inline]
+pub fn to_i64(d: &[u8]) -> i64 {
+    i64::from_le_bytes(d.try_into().unwrap())
+}

--- a/cases/src/misc_cases.rs
+++ b/cases/src/misc_cases.rs
@@ -1,6 +1,4 @@
-use ckb_std::syscalls::debug;
 use core::arch::asm;
-use rvv_testcases::log;
 
 fn add(lhs: u64, rhs: u64) -> u64 {
     let mut result: u64;
@@ -14,7 +12,6 @@ pub fn test_add() {
     let lhs = 1u64;
     let rhs = 0u64;
     let result = add(lhs, rhs);
-    log!("test_add, result = {}", result);
     assert_eq!(result, lhs + rhs);
 }
 
@@ -50,7 +47,6 @@ pub fn test_add_array() {
     let lhs = [1, 2, 3, 4];
     let rhs = [2, 3, 4, 5];
     add_array(&lhs, &rhs, &mut result);
-    log!("test_add_array, result = {}", result[0]);
     assert_eq!(result[1], 5);
     assert_eq!(result[2], 7);
     assert_eq!(result[3], 9);

--- a/cases/src/narrowing_fixed_point_clip_cases.rs
+++ b/cases/src/narrowing_fixed_point_clip_cases.rs
@@ -3,10 +3,10 @@ use eint::{Eint, E256, E512};
 use rvv_asm::rvv_asm;
 use rvv_testcases::{
     misc::conver_to_i512,
-    runner::{run_template_wi, run_template_wv, run_template_wx, MaskType},
+    runner::{run_template_v_wi, run_template_v_wv, run_template_v_wx, MaskType},
 };
 
-fn expected_op_vnclipu(result: &mut [u8], lhs: &[u8], x: u64) {
+fn expected_op_vnclipu(lhs: &[u8], x: u64, result: &mut [u8]) {
     assert_eq!(lhs.len(), result.len() * 2);
 
     match result.len() {
@@ -38,7 +38,7 @@ fn expected_op_vnclipu(result: &mut [u8], lhs: &[u8], x: u64) {
     }
 }
 fn test_vnclipu_wv() {
-    fn exp_op(result: &mut [u8], lhs: &[u8], rhs: &[u8]) {
+    fn exp_op(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         let x = match rhs.len() {
             8 => u64::from_le_bytes(rhs.try_into().unwrap()),
             32 => E256::get(rhs).u64(),
@@ -46,7 +46,7 @@ fn test_vnclipu_wv() {
                 panic!("unsupported length: {}", rhs.len());
             }
         };
-        expected_op_vnclipu(result, lhs, x)
+        expected_op_vnclipu(lhs, x, result)
     }
     fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
         unsafe {
@@ -62,7 +62,7 @@ fn test_vnclipu_wv() {
         }
     }
 
-    run_template_wv(exp_op, op, &[64, 256], &[-2, 1, 2], true, "vnclipu.wv");
+    run_template_v_wv(exp_op, op, true, "vnclipu.wv");
 }
 fn test_vnclipu_wx() {
     fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
@@ -80,18 +80,11 @@ fn test_vnclipu_wx() {
         }
     }
 
-    run_template_wx(
-        expected_op_vnclipu,
-        op,
-        &[64, 256],
-        &[-2, 1, 2],
-        true,
-        "vnclipu.wx",
-    );
+    run_template_v_wx(expected_op_vnclipu, op, true, "vnclipu.wx");
 }
 fn test_vnclipu_wi() {
-    fn exp_op(result: &mut [u8], lhs: &[u8], x: i64) {
-        expected_op_vnclipu(result, lhs, x as u64);
+    fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
+        expected_op_vnclipu(lhs, x as u64, result);
     }
     fn op(_: &[u8], rhs: &[u8], _: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
@@ -200,10 +193,10 @@ fn test_vnclipu_wi() {
         }
     }
 
-    run_template_wi(exp_op, op, &[64, 256], &[-2, 1, 2], "vnclipu.wi");
+    run_template_v_wi(exp_op, op, "vnclipu.wi");
 }
 
-fn expected_op_vnclip(result: &mut [u8], lhs: &[u8], x: u64) {
+fn expected_op_vnclip(lhs: &[u8], x: u64, result: &mut [u8]) {
     assert_eq!(lhs.len(), result.len() * 2);
 
     match result.len() {
@@ -239,7 +232,7 @@ fn expected_op_vnclip(result: &mut [u8], lhs: &[u8], x: u64) {
     }
 }
 fn test_vnclip_wv() {
-    fn exp_op(result: &mut [u8], lhs: &[u8], rhs: &[u8]) {
+    fn exp_op(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         let x = match rhs.len() {
             8 => u64::from_le_bytes(rhs.try_into().unwrap()),
             32 => E256::get(rhs).u64(),
@@ -247,7 +240,7 @@ fn test_vnclip_wv() {
                 panic!("unsupported length: {}", rhs.len());
             }
         };
-        expected_op_vnclip(result, lhs, x)
+        expected_op_vnclip(lhs, x, result)
     }
     fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
         unsafe {
@@ -263,7 +256,7 @@ fn test_vnclip_wv() {
         }
     }
 
-    run_template_wv(exp_op, op, &[64, 256], &[-2, 1, 2], true, "vnclip.wv");
+    run_template_v_wv(exp_op, op, true, "vnclip.wv");
 }
 fn test_vnclip_wx() {
     fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
@@ -281,18 +274,11 @@ fn test_vnclip_wx() {
         }
     }
 
-    run_template_wx(
-        expected_op_vnclip,
-        op,
-        &[64, 256],
-        &[-2, 1, 2],
-        true,
-        "vnclip.wx",
-    );
+    run_template_v_wx(expected_op_vnclip, op, true, "vnclip.wx");
 }
 fn test_vnclip_wi() {
-    fn exp_op(result: &mut [u8], lhs: &[u8], x: i64) {
-        expected_op_vnclip(result, lhs, x as u64);
+    fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
+        expected_op_vnclip(lhs, x as u64, result);
     }
     fn op(_: &[u8], rhs: &[u8], _: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
@@ -401,7 +387,7 @@ fn test_vnclip_wi() {
         }
     }
 
-    run_template_wi(exp_op, op, &[64, 256], &[-2, 1, 2], "vnclip.wi");
+    run_template_v_wi(exp_op, op, "vnclip.wi");
 }
 
 pub fn test_narrowing_fixed_point_clip() {

--- a/cases/src/narrowing_fixed_point_clip_cases.rs
+++ b/cases/src/narrowing_fixed_point_clip_cases.rs
@@ -86,106 +86,298 @@ fn test_vnclipu_wi() {
     fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
         expected_op_vnclipu(lhs, x as u64, result);
     }
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                0 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 0");
-                }
-                1 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 1");
-                }
-                2 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 2");
-                }
-                3 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 3");
-                }
-                4 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 4");
-                }
-                5 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 5");
-                }
-                6 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 6");
-                }
-                7 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 7");
-                }
-                8 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 8");
-                }
-                9 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 9");
-                }
-                10 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 10");
-                }
-                11 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 11");
-                }
-                12 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 12");
-                }
-                13 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 13");
-                }
-                14 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 14");
-                }
-                15 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 15");
-                }
-                16 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 16");
-                }
-                17 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 17");
-                }
-                18 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 18");
-                }
-                19 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 19");
-                }
-                20 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 20");
-                }
-                21 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 21");
-                }
-                22 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 22");
-                }
-                23 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 23");
-                }
-                24 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 24");
-                }
-                25 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 25");
-                }
-                26 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 26");
-                }
-                27 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 27");
-                }
-                28 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 28");
-                }
-                29 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 29");
-                }
-                30 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 30");
-                }
-                31 => {
-                    rvv_asm!("vnclipu.wi v24, v8, 31");
-                }
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                17 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 17, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 17");
+                    }
+                    _ => panic!("Abort"),
+                },
+                18 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 18, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 18");
+                    }
+                    _ => panic!("Abort"),
+                },
+                19 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 19, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 19");
+                    }
+                    _ => panic!("Abort"),
+                },
+                20 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 20, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 20");
+                    }
+                    _ => panic!("Abort"),
+                },
+                21 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 21, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 21");
+                    }
+                    _ => panic!("Abort"),
+                },
+                22 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 22, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 22");
+                    }
+                    _ => panic!("Abort"),
+                },
+                23 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 23, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 23");
+                    }
+                    _ => panic!("Abort"),
+                },
+                24 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 24, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 24");
+                    }
+                    _ => panic!("Abort"),
+                },
+                25 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 25, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 25");
+                    }
+                    _ => panic!("Abort"),
+                },
+                26 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 26, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 26");
+                    }
+                    _ => panic!("Abort"),
+                },
+                27 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 27, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 27");
+                    }
+                    _ => panic!("Abort"),
+                },
+                28 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 28, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 28");
+                    }
+                    _ => panic!("Abort"),
+                },
+                29 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 29, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 29");
+                    }
+                    _ => panic!("Abort"),
+                },
+                30 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 30, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 30");
+                    }
+                    _ => panic!("Abort"),
+                },
+                31 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 31, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclipu.wi v24, v8, 31");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
                     panic!("Abort");
                 }
@@ -280,106 +472,298 @@ fn test_vnclip_wi() {
     fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
         expected_op_vnclip(lhs, x as u64, result);
     }
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                0 => {
-                    rvv_asm!("vnclip.wi v24, v8, 0");
-                }
-                1 => {
-                    rvv_asm!("vnclip.wi v24, v8, 1");
-                }
-                2 => {
-                    rvv_asm!("vnclip.wi v24, v8, 2");
-                }
-                3 => {
-                    rvv_asm!("vnclip.wi v24, v8, 3");
-                }
-                4 => {
-                    rvv_asm!("vnclip.wi v24, v8, 4");
-                }
-                5 => {
-                    rvv_asm!("vnclip.wi v24, v8, 5");
-                }
-                6 => {
-                    rvv_asm!("vnclip.wi v24, v8, 6");
-                }
-                7 => {
-                    rvv_asm!("vnclip.wi v24, v8, 7");
-                }
-                8 => {
-                    rvv_asm!("vnclip.wi v24, v8, 8");
-                }
-                9 => {
-                    rvv_asm!("vnclip.wi v24, v8, 9");
-                }
-                10 => {
-                    rvv_asm!("vnclip.wi v24, v8, 10");
-                }
-                11 => {
-                    rvv_asm!("vnclip.wi v24, v8, 11");
-                }
-                12 => {
-                    rvv_asm!("vnclip.wi v24, v8, 12");
-                }
-                13 => {
-                    rvv_asm!("vnclip.wi v24, v8, 13");
-                }
-                14 => {
-                    rvv_asm!("vnclip.wi v24, v8, 14");
-                }
-                15 => {
-                    rvv_asm!("vnclip.wi v24, v8, 15");
-                }
-                16 => {
-                    rvv_asm!("vnclip.wi v24, v8, 16");
-                }
-                17 => {
-                    rvv_asm!("vnclip.wi v24, v8, 17");
-                }
-                18 => {
-                    rvv_asm!("vnclip.wi v24, v8, 18");
-                }
-                19 => {
-                    rvv_asm!("vnclip.wi v24, v8, 19");
-                }
-                20 => {
-                    rvv_asm!("vnclip.wi v24, v8, 20");
-                }
-                21 => {
-                    rvv_asm!("vnclip.wi v24, v8, 21");
-                }
-                22 => {
-                    rvv_asm!("vnclip.wi v24, v8, 22");
-                }
-                23 => {
-                    rvv_asm!("vnclip.wi v24, v8, 23");
-                }
-                24 => {
-                    rvv_asm!("vnclip.wi v24, v8, 24");
-                }
-                25 => {
-                    rvv_asm!("vnclip.wi v24, v8, 25");
-                }
-                26 => {
-                    rvv_asm!("vnclip.wi v24, v8, 26");
-                }
-                27 => {
-                    rvv_asm!("vnclip.wi v24, v8, 27");
-                }
-                28 => {
-                    rvv_asm!("vnclip.wi v24, v8, 28");
-                }
-                29 => {
-                    rvv_asm!("vnclip.wi v24, v8, 29");
-                }
-                30 => {
-                    rvv_asm!("vnclip.wi v24, v8, 30");
-                }
-                31 => {
-                    rvv_asm!("vnclip.wi v24, v8, 31");
-                }
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                17 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 17, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 17");
+                    }
+                    _ => panic!("Abort"),
+                },
+                18 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 18, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 18");
+                    }
+                    _ => panic!("Abort"),
+                },
+                19 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 19, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 19");
+                    }
+                    _ => panic!("Abort"),
+                },
+                20 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 20, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 20");
+                    }
+                    _ => panic!("Abort"),
+                },
+                21 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 21, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 21");
+                    }
+                    _ => panic!("Abort"),
+                },
+                22 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 22, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 22");
+                    }
+                    _ => panic!("Abort"),
+                },
+                23 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 23, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 23");
+                    }
+                    _ => panic!("Abort"),
+                },
+                24 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 24, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 24");
+                    }
+                    _ => panic!("Abort"),
+                },
+                25 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 25, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 25");
+                    }
+                    _ => panic!("Abort"),
+                },
+                26 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 26, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 26");
+                    }
+                    _ => panic!("Abort"),
+                },
+                27 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 27, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 27");
+                    }
+                    _ => panic!("Abort"),
+                },
+                28 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 28, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 28");
+                    }
+                    _ => panic!("Abort"),
+                },
+                29 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 29, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 29");
+                    }
+                    _ => panic!("Abort"),
+                },
+                30 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 30, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 30");
+                    }
+                    _ => panic!("Abort"),
+                },
+                31 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnclip.wi v24, v8, 31, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnclip.wi v24, v8, 31");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
                     panic!("Abort");
                 }

--- a/cases/src/narrowing_integer_right_shift_cases.rs
+++ b/cases/src/narrowing_integer_right_shift_cases.rs
@@ -4,10 +4,10 @@ use eint::{Eint, E128, E256, E512};
 use rvv_asm::rvv_asm;
 use rvv_testcases::{
     misc::{U256, U512},
-    runner::{run_template_wi, run_template_wv, run_template_wx, MaskType},
+    runner::{run_template_v_wi, run_template_v_wv, run_template_v_wx, MaskType},
 };
 
-fn expected_op_srl(result: &mut [u8], lhs: &[u8], x: u64) {
+fn expected_op_srl(lhs: &[u8], x: u64, result: &mut [u8]) {
     assert_eq!(lhs.len(), result.len() * 2);
 
     match result.len() {
@@ -32,13 +32,13 @@ fn expected_op_srl(result: &mut [u8], lhs: &[u8], x: u64) {
 }
 
 fn test_vnsrl_wv() {
-    fn exp_op(result: &mut [u8], lhs: &[u8], rhs: &[u8]) {
+    fn exp_op(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         let x = match rhs.len() {
             8 => u64::from_le_bytes(rhs.try_into().unwrap()),
             32 => E256::get(rhs).u64(),
             _ => panic!("Abort"),
         };
-        expected_op_srl(result, lhs, x);
+        expected_op_srl(lhs, x, result);
     }
     fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
         unsafe {
@@ -54,7 +54,7 @@ fn test_vnsrl_wv() {
         }
     }
 
-    run_template_wv(exp_op, op, &[64, 256], &[-2, 1, 2], true, "vnsrl.wv");
+    run_template_v_wv(exp_op, op, true, "vnsrl.wv");
 }
 
 fn test_vnsrl_wx() {
@@ -73,19 +73,12 @@ fn test_vnsrl_wx() {
         }
     }
 
-    run_template_wx(
-        expected_op_srl,
-        op,
-        &[64, 256],
-        &[-2, 1, 2],
-        true,
-        "vnsrl.wx",
-    );
+    run_template_v_wx(expected_op_srl, op, true, "vnsrl.wx");
 }
 
 fn test_vnsrl_wi() {
-    fn exp_op(result: &mut [u8], lhs: &[u8], x: i64) {
-        expected_op_srl(result, lhs, x as u64);
+    fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
+        expected_op_srl(lhs, x as u64, result);
     }
     fn op(_: &[u8], rhs: &[u8], _: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
@@ -194,7 +187,7 @@ fn test_vnsrl_wi() {
         }
     }
 
-    run_template_wi(exp_op, op, &[64, 256], &[-2, 1, 2], "vnsrl.wi")
+    run_template_v_wi(exp_op, op, "vnsrl.wi")
 }
 
 pub fn test_narrowing_integer_right_shift() {
@@ -203,7 +196,7 @@ pub fn test_narrowing_integer_right_shift() {
     test_vnsrl_wi();
 }
 
-fn expected_op_arithmetic(result: &mut [u8], lhs: &[u8], x: u64) {
+fn expected_op_arithmetic(lhs: &[u8], x: u64, result: &mut [u8]) {
     assert_eq!(lhs.len(), result.len() * 2);
 
     match result.len() {
@@ -234,13 +227,13 @@ fn expected_op_arithmetic(result: &mut [u8], lhs: &[u8], x: u64) {
 }
 
 fn test_vnsra_wv() {
-    fn exp_op(result: &mut [u8], lhs: &[u8], rhs: &[u8]) {
+    fn exp_op(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         let x = match rhs.len() {
             8 => u64::from_le_bytes(rhs.try_into().unwrap()),
             32 => E256::get(rhs).u64(),
             _ => panic!("Abort"),
         };
-        expected_op_arithmetic(result, lhs, x);
+        expected_op_arithmetic(lhs, x, result);
     }
     fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
         unsafe {
@@ -256,7 +249,7 @@ fn test_vnsra_wv() {
         }
     }
 
-    run_template_wv(exp_op, op, &[64, 256], &[-2, 1, 2], true, "vnsra.wv");
+    run_template_v_wv(exp_op, op, true, "vnsra.wv");
 }
 
 fn test_vnsra_wx() {
@@ -275,19 +268,12 @@ fn test_vnsra_wx() {
         }
     }
 
-    run_template_wx(
-        expected_op_arithmetic,
-        op,
-        &[64, 256],
-        &[-2, 1, 2],
-        true,
-        "vnsra.wx",
-    );
+    run_template_v_wx(expected_op_arithmetic, op, true, "vnsra.wx");
 }
 
 fn test_vnsra_wi() {
-    fn exp_op(result: &mut [u8], lhs: &[u8], x: i64) {
-        expected_op_arithmetic(result, lhs, x as u64);
+    fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
+        expected_op_arithmetic(lhs, x as u64, result);
     }
     fn op(_: &[u8], rhs: &[u8], _: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
@@ -396,7 +382,7 @@ fn test_vnsra_wi() {
         }
     }
 
-    run_template_wi(exp_op, op, &[64, 256], &[-2, 1, 2], "vnsra.wi")
+    run_template_v_wi(exp_op, op, "vnsra.wi")
 }
 
 pub fn test_narrowing_integer_right_shift_arithmetic() {

--- a/cases/src/narrowing_integer_right_shift_cases.rs
+++ b/cases/src/narrowing_integer_right_shift_cases.rs
@@ -80,106 +80,298 @@ fn test_vnsrl_wi() {
     fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
         expected_op_srl(lhs, x as u64, result);
     }
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                0 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 0");
-                }
-                1 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 1");
-                }
-                2 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 2");
-                }
-                3 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 3");
-                }
-                4 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 4");
-                }
-                5 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 5");
-                }
-                6 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 6");
-                }
-                7 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 7");
-                }
-                8 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 8");
-                }
-                9 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 9");
-                }
-                10 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 10");
-                }
-                11 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 11");
-                }
-                12 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 12");
-                }
-                13 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 13");
-                }
-                14 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 14");
-                }
-                15 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 15");
-                }
-                16 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 16");
-                }
-                17 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 17");
-                }
-                18 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 18");
-                }
-                19 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 19");
-                }
-                20 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 20");
-                }
-                21 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 21");
-                }
-                22 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 22");
-                }
-                23 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 23");
-                }
-                24 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 24");
-                }
-                25 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 25");
-                }
-                26 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 26");
-                }
-                27 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 27");
-                }
-                28 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 28");
-                }
-                29 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 29");
-                }
-                30 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 30");
-                }
-                31 => {
-                    rvv_asm!("vnsrl.wi v24, v8, 31");
-                }
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                17 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 17, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 17");
+                    }
+                    _ => panic!("Abort"),
+                },
+                18 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 18, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 18");
+                    }
+                    _ => panic!("Abort"),
+                },
+                19 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 19, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 19");
+                    }
+                    _ => panic!("Abort"),
+                },
+                20 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 20, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 20");
+                    }
+                    _ => panic!("Abort"),
+                },
+                21 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 21, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 21");
+                    }
+                    _ => panic!("Abort"),
+                },
+                22 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 22, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 22");
+                    }
+                    _ => panic!("Abort"),
+                },
+                23 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 23, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 23");
+                    }
+                    _ => panic!("Abort"),
+                },
+                24 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 24, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 24");
+                    }
+                    _ => panic!("Abort"),
+                },
+                25 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 25, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 25");
+                    }
+                    _ => panic!("Abort"),
+                },
+                26 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 26, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 26");
+                    }
+                    _ => panic!("Abort"),
+                },
+                27 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 27, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 27");
+                    }
+                    _ => panic!("Abort"),
+                },
+                28 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 28, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 28");
+                    }
+                    _ => panic!("Abort"),
+                },
+                29 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 29, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 29");
+                    }
+                    _ => panic!("Abort"),
+                },
+                30 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 30, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 30");
+                    }
+                    _ => panic!("Abort"),
+                },
+                31 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 31, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsrl.wi v24, v8, 31");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
                     panic!("Abort");
                 }
@@ -275,106 +467,298 @@ fn test_vnsra_wi() {
     fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
         expected_op_arithmetic(lhs, x as u64, result);
     }
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                0 => {
-                    rvv_asm!("vnsra.wi v24, v8, 0");
-                }
-                1 => {
-                    rvv_asm!("vnsra.wi v24, v8, 1");
-                }
-                2 => {
-                    rvv_asm!("vnsra.wi v24, v8, 2");
-                }
-                3 => {
-                    rvv_asm!("vnsra.wi v24, v8, 3");
-                }
-                4 => {
-                    rvv_asm!("vnsra.wi v24, v8, 4");
-                }
-                5 => {
-                    rvv_asm!("vnsra.wi v24, v8, 5");
-                }
-                6 => {
-                    rvv_asm!("vnsra.wi v24, v8, 6");
-                }
-                7 => {
-                    rvv_asm!("vnsra.wi v24, v8, 7");
-                }
-                8 => {
-                    rvv_asm!("vnsra.wi v24, v8, 8");
-                }
-                9 => {
-                    rvv_asm!("vnsra.wi v24, v8, 9");
-                }
-                10 => {
-                    rvv_asm!("vnsra.wi v24, v8, 10");
-                }
-                11 => {
-                    rvv_asm!("vnsra.wi v24, v8, 11");
-                }
-                12 => {
-                    rvv_asm!("vnsra.wi v24, v8, 12");
-                }
-                13 => {
-                    rvv_asm!("vnsra.wi v24, v8, 13");
-                }
-                14 => {
-                    rvv_asm!("vnsra.wi v24, v8, 14");
-                }
-                15 => {
-                    rvv_asm!("vnsra.wi v24, v8, 15");
-                }
-                16 => {
-                    rvv_asm!("vnsra.wi v24, v8, 16");
-                }
-                17 => {
-                    rvv_asm!("vnsra.wi v24, v8, 17");
-                }
-                18 => {
-                    rvv_asm!("vnsra.wi v24, v8, 18");
-                }
-                19 => {
-                    rvv_asm!("vnsra.wi v24, v8, 19");
-                }
-                20 => {
-                    rvv_asm!("vnsra.wi v24, v8, 20");
-                }
-                21 => {
-                    rvv_asm!("vnsra.wi v24, v8, 21");
-                }
-                22 => {
-                    rvv_asm!("vnsra.wi v24, v8, 22");
-                }
-                23 => {
-                    rvv_asm!("vnsra.wi v24, v8, 23");
-                }
-                24 => {
-                    rvv_asm!("vnsra.wi v24, v8, 24");
-                }
-                25 => {
-                    rvv_asm!("vnsra.wi v24, v8, 25");
-                }
-                26 => {
-                    rvv_asm!("vnsra.wi v24, v8, 26");
-                }
-                27 => {
-                    rvv_asm!("vnsra.wi v24, v8, 27");
-                }
-                28 => {
-                    rvv_asm!("vnsra.wi v24, v8, 28");
-                }
-                29 => {
-                    rvv_asm!("vnsra.wi v24, v8, 29");
-                }
-                30 => {
-                    rvv_asm!("vnsra.wi v24, v8, 30");
-                }
-                31 => {
-                    rvv_asm!("vnsra.wi v24, v8, 31");
-                }
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                17 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 17, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 17");
+                    }
+                    _ => panic!("Abort"),
+                },
+                18 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 18, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 18");
+                    }
+                    _ => panic!("Abort"),
+                },
+                19 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 19, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 19");
+                    }
+                    _ => panic!("Abort"),
+                },
+                20 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 20, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 20");
+                    }
+                    _ => panic!("Abort"),
+                },
+                21 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 21, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 21");
+                    }
+                    _ => panic!("Abort"),
+                },
+                22 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 22, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 22");
+                    }
+                    _ => panic!("Abort"),
+                },
+                23 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 23, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 23");
+                    }
+                    _ => panic!("Abort"),
+                },
+                24 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 24, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 24");
+                    }
+                    _ => panic!("Abort"),
+                },
+                25 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 25, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 25");
+                    }
+                    _ => panic!("Abort"),
+                },
+                26 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 26, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 26");
+                    }
+                    _ => panic!("Abort"),
+                },
+                27 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 27, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 27");
+                    }
+                    _ => panic!("Abort"),
+                },
+                28 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 28, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 28");
+                    }
+                    _ => panic!("Abort"),
+                },
+                29 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 29, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 29");
+                    }
+                    _ => panic!("Abort"),
+                },
+                30 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 30, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 30");
+                    }
+                    _ => panic!("Abort"),
+                },
+                31 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vnsra.wi v24, v8, 31, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vnsra.wi v24, v8, 31");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
                     panic!("Abort");
                 }

--- a/cases/src/runner.rs
+++ b/cases/src/runner.rs
@@ -1,17 +1,20 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::convert::TryInto;
+use core::fmt::{Display, Formatter, Result};
 use core::ops::Range;
 
 use ckb_std::syscalls::debug;
-use rand::{Rng, RngCore};
+use rand::Rng;
 
-use crate::intrinsic::{vl1r_v0, clean_cache_v8, clean_cache_v16, vle_v16, vle_v24, vle_v8, vse_v24, vsetvl};
+use crate::intrinsic::{
+    clean_cache_v16, clean_cache_v8, vl1r_v0, vle_v16, vle_v24, vle_v8, vse_v24, vsetvl,
+};
 use crate::misc::{avl_iterator, VLEN};
-use crate::rng::{new_random01_vec, new_random_vec};
 
+use super::dbg_log;
 use super::log;
-use super::misc::{ceiling, get_bit_in_slice, is_verbose, set_bit_in_slice};
+use super::misc::{get_bit_in_slice, is_verbose, set_bit_in_slice};
 use super::rng::BestNumberRng;
 
 pub enum WideningCategory {
@@ -29,281 +32,6 @@ pub enum ExpectedOp {
     Reduction(Box<dyn FnMut(&[u8], &[u8], &mut [u8], usize)>),
     EnableMask(Box<dyn FnMut(&[u8], &[u8], &mut [u8], bool, usize)>),
     WithMask(Box<dyn FnMut(&[u8], &[u8], &mut [u8], u8)>),
-}
-
-pub fn run_vop_vv<T>(
-    sew: u64,
-    lmul: i64,
-    avl: u64,
-    mut expected_op: ExpectedOp,
-    mut v_op: T,
-    cat: WideningCategory,
-    desc: &str,
-) where
-    T: FnMut(&[u8], &[u8], &mut [u8], u64, i64, u64),
-{
-    if is_verbose() {
-        log!(
-            "run with sew = {}, lmul = {}, avl = {}, desc = {}",
-            sew,
-            lmul,
-            avl,
-            desc
-        );
-    }
-    let vl = vsetvl(avl as u64, sew, lmul);
-    if vl == 0 {
-        return;
-    }
-
-    let avl_bytes = (sew / 8 * avl) as usize;
-    let sew_bytes = (sew / 8) as usize;
-
-    let mut rhs = Vec::<u8>::new();
-    rhs.resize(avl_bytes, 0u8);
-
-    let mut lhs = Vec::<u8>::new();
-    // some destructive instructions, like vmacc.vv, require `expected` filled before executing.
-    // `expected_before` is the place to put random values.
-    let mut expected_before = Vec::<u8>::new();
-    let mut expected = Vec::<u8>::new();
-    let mut result = Vec::<u8>::new();
-
-    match cat {
-        WideningCategory::VdVs1 => {
-            expected.resize(avl_bytes * 2, 0);
-            result.resize(avl_bytes * 2, 0);
-            lhs.resize(avl_bytes, 0);
-            rhs.resize(avl_bytes * 2, 0u8);
-        }
-        WideningCategory::VdVs2 => {
-            expected.resize(avl_bytes * 2, 0);
-            result.resize(avl_bytes * 2, 0);
-            lhs.resize(avl_bytes * 2, 0);
-        }
-        WideningCategory::VdOnly => {
-            expected.resize(avl_bytes * 2, 0);
-            result.resize(avl_bytes * 2, 0);
-            lhs.resize(avl_bytes, 0);
-        }
-        WideningCategory::NarrowVs2(n) => {
-            expected.resize(avl_bytes, 0);
-            result.resize(avl_bytes, 0);
-            lhs.resize(avl_bytes / n, 0);
-        }
-        WideningCategory::Vs2Only => {
-            expected.resize(avl_bytes, 0);
-            result.resize(avl_bytes, 0);
-            lhs.resize(avl_bytes * 2, 0);
-        }
-        _ => {
-            expected.resize(avl_bytes, 0);
-            result.resize(avl_bytes, 0);
-            lhs.resize(avl_bytes, 0);
-        }
-    }
-    expected_before.resize(expected.len(), 0);
-
-    let mut rng = BestNumberRng::default();
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-        let expected_range = match cat {
-            WideningCategory::VdVs2 => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            WideningCategory::VdOnly => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            _ => range.clone(),
-        };
-        let lhs_range = match cat {
-            WideningCategory::VdVs2 => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            WideningCategory::Vs2Only => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            WideningCategory::NarrowVs2(n) => i * sew_bytes / n..(i + 1) * sew_bytes / n,
-            _ => range.clone(),
-        };
-        let rhs_range = match cat {
-            WideningCategory::VdVs1 => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            _ => range.clone(),
-        };
-
-        rng.fill(&mut lhs[lhs_range.clone()]);
-        rng.fill(&mut rhs[rhs_range.clone()]);
-        rng.fill(&mut expected_before[expected_range.clone()]);
-        expected[expected_range.clone()].copy_from_slice(&expected_before[expected_range.clone()]);
-
-        if result.len() == expected_before.len() {
-            result[expected_range.clone()]
-                .copy_from_slice(&expected_before[expected_range.clone()]);
-        }
-
-        match expected_op {
-            ExpectedOp::Normal(ref mut op) => {
-                op(
-                    &lhs[lhs_range.clone()],
-                    &rhs[rhs_range.clone()],
-                    &mut expected[expected_range.clone()],
-                );
-            }
-            ExpectedOp::Reduction(ref mut op) => {
-                let expected_range = match cat {
-                    WideningCategory::VdVs1 => 0..sew_bytes * 2,
-                    WideningCategory::VdVs2 => 0..sew_bytes * 2,
-                    WideningCategory::VdOnly => 0..sew_bytes * 2,
-                    _ => 0..sew_bytes,
-                };
-                // vs2: lhs, vs1: rhs
-                //  # vd[0] =  sum(vs2[*], vs1[0])
-                let index = i % vl as usize;
-                if index == 0 {
-                    rhs[rhs_range.clone()].copy_from_slice(&expected[expected_range.clone()]);
-                }
-                op(
-                    &lhs[lhs_range.clone()],
-                    &rhs[rhs_range.clone()],
-                    &mut expected[expected_range.clone()],
-                    index,
-                );
-            }
-            _ => {
-                panic!("unexpected op")
-            }
-        }
-    }
-    v_op(
-        lhs.as_slice(),
-        rhs.as_slice(),
-        result.as_mut_slice(),
-        sew,
-        lmul,
-        avl,
-    );
-
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-        let expected_range = match cat {
-            WideningCategory::VdVs2 | WideningCategory::VdOnly => {
-                i * sew_bytes * 2..(i + 1) * sew_bytes * 2
-            }
-            _ => range.clone(),
-        };
-        let lhs_range = match cat {
-            WideningCategory::VdVs2 => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            WideningCategory::Vs2Only => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            WideningCategory::NarrowVs2(n) => i * sew_bytes / n..(i + 1) * sew_bytes / n,
-            _ => range.clone(),
-        };
-        let rhs_range = match cat {
-            WideningCategory::VdVs1 => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            _ => range.clone(),
-        };
-
-        let left = &lhs[lhs_range.clone()];
-        let right = &rhs[rhs_range.clone()];
-
-        let res = &result[expected_range.clone()];
-        let exp = &expected[expected_range.clone()];
-        let exp_before = if result.len() == expected_before.len() {
-            &expected_before[expected_range.clone()]
-        } else {
-            &[]
-        };
-        if res != exp {
-            log!(
-                "[sew = {}, describe = {}] unexpected values found at index {}: {:0>2X?} (result) {:0>2X?} (expected)",
-                sew, desc, i, res, exp
-            );
-            log!(
-                "more information, lhs = {:0>2X?}, rhs = {:0>2X?}, expected_before = {:0>2X?}, lmul = {}, avl = {}",
-                left,
-                right,
-                exp_before,
-                lmul,
-                avl
-            );
-            panic!("Abort");
-        }
-        // for reduction operations, it only checks the first element
-        if let ExpectedOp::Reduction(_) = expected_op {
-            break;
-        }
-    }
-    if is_verbose() {
-        log!("finished");
-    }
-}
-
-pub fn run_vop_vvm<T>(
-    sew: u64,
-    lmul: i64,
-    avl: u64,
-    mut expected_op: ExpectedOp,
-    mut v_op: T,
-    desc: &str,
-) where
-    T: FnMut(&[u8], &[u8], &mut [u8], &[u8], u64, i64, u64),
-{
-    if is_verbose() {
-        log!(
-            "run with sew = {}, lmul = {}, avl = {}, desc = {}",
-            sew,
-            lmul,
-            avl,
-            desc
-        );
-    }
-
-    let avl_bytes = (sew / 8 * avl) as usize;
-    let sew_bytes = (sew / 8) as usize;
-
-    let lhs = new_random_vec(avl_bytes);
-    let rhs = new_random_vec(avl_bytes);
-    let mut expected = new_random_vec(avl_bytes);
-    let mut result = new_random_vec(avl_bytes);
-    let masks = new_random01_vec(avl as usize);
-
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-        if let ExpectedOp::WithMask(ref mut op) = expected_op {
-            op(
-                &lhs[range.clone()],
-                &rhs[range.clone()],
-                &mut expected[range.clone()],
-                masks[i],
-            );
-        }
-    }
-    v_op(
-        lhs.as_slice(),
-        rhs.as_slice(),
-        result.as_mut_slice(),
-        masks.as_slice(),
-        sew,
-        lmul,
-        avl,
-    );
-
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-        let left = &lhs[range.clone()];
-        let right = &rhs[range.clone()];
-
-        let res = &result[range.clone()];
-        let exp = &expected[range.clone()];
-        if res != exp {
-            log!(
-                "[sew = {}, describe = {}] unexpected values found at index {}: {:?} (result) {:?} (expected)",
-                sew, desc, i, res, exp
-            );
-            log!(
-                "more information, lhs = {:?}, rhs = {:?}, lmul = {}, avl = {}",
-                left,
-                right,
-                lmul,
-                avl
-            );
-            panic!("Abort");
-        }
-    }
-    if is_verbose() {
-        log!("finished");
-    }
 }
 
 pub fn run_vxop_m<T>(mut expected_op: ExpectedOp, mut v_op: T, enable_mask: bool, desc: &str)
@@ -354,561 +82,63 @@ where
     }
 }
 
-pub fn run_vmop_mm<T>(
-    sew: u64,
-    lmul: i64,
-    avl: u64,
-    mut expected_op: ExpectedOp,
-    mut v_op: T,
-    desc: &str,
-) where
-    T: FnMut(&[u8], &[u8], &mut [u8], u64, i64, u64),
-{
-    if is_verbose() {
-        log!(
-            "run with sew = {}, lmul = {}, avl = {}, desc = {}",
-            sew,
-            lmul,
-            avl,
-            desc
-        );
-    }
-    let avl_bytes = (avl / 8) as usize;
-    assert!(avl_bytes <= VLEN / 8);
-
-    let mut rhs = Vec::<u8>::new();
-    rhs.resize(avl_bytes, 0u8);
-
-    let mut lhs = Vec::<u8>::new();
-    let mut expected = Vec::<u8>::new();
-    let mut result = Vec::<u8>::new();
-
-    expected.resize(avl_bytes, 0);
-    result.resize(avl_bytes, 0);
-    lhs.resize(avl_bytes, 0);
-
-    let mut rng = BestNumberRng::default();
-    for i in 0..avl_bytes as usize {
-        rng.fill(&mut lhs[i..i + 1]);
-        rng.fill(&mut rhs[i..i + 1]);
-
-        if let ExpectedOp::Normal(ref mut op) = expected_op {
-            op(&lhs[i..i + 1], &rhs[i..i + 1], &mut expected[i..i + 1]);
-        } else {
-            panic!("Unexpected op")
-        }
-    }
-
-    // why?
-    let expected = expected.clone();
-
-    v_op(
-        lhs.as_slice(),
-        rhs.as_slice(),
-        result.as_mut_slice(),
-        sew,
-        lmul,
-        avl,
-    );
-
-    for i in 0..avl_bytes as usize {
-        let res = result[i];
-        let exp = expected[i];
-
-        if res != exp {
-            log!(
-                "[sew = {}, describe = {}] unexpected values found at index {}: {:0>2X?} (result) {:0>2X?} (expected)",
-                sew, desc, i, res, exp
-            );
-            panic!("Abort");
-        }
-    }
-    if is_verbose() {
-        log!("finished");
-    }
-}
-
-pub fn run_vmsop_vv<T1, T2>(
-    sew: u64,
-    lmul: i64,
-    avl: u64,
-    mut expected_op: T1,
-    mut v_op: T2,
-    _: WideningCategory,
-    desc: &str,
-) where
-    T1: FnMut(&[u8], &[u8], &mut [u8], usize),
-    T2: FnMut(&[u8], &[u8], &mut [u8], u64, i64, u64),
-{
-    if is_verbose() {
-        log!(
-            "run with sew = {}, lmul = {}, avl = {}, desc = {}",
-            sew,
-            lmul,
-            avl,
-            desc
-        );
-    }
-    let vl = vsetvl(avl as u64, sew, lmul);
-    if vl == 0 {
-        return;
-    }
-
-    let avl_bytes = (sew / 8 * avl) as usize;
-    let sew_bytes = (sew / 8) as usize;
-
-    let mut rhs = Vec::<u8>::new();
-    rhs.resize(avl_bytes, 0u8);
-    let mut lhs = Vec::<u8>::new();
-    lhs.resize(avl_bytes, 0);
-
-    let mut expected = Vec::<u8>::new();
-    let mut result = Vec::<u8>::new();
-
-    let result_avl_bytes = ceiling(avl as usize, 8);
-    result.resize(result_avl_bytes, 0);
-    expected.resize(result_avl_bytes, 0);
-
-    let mut rng = BestNumberRng::default();
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-
-        rng.fill(&mut lhs[range.clone()]);
-        rng.fill(&mut rhs[range.clone()]);
-
-        expected_op(&lhs[range.clone()], &rhs[range.clone()], &mut expected, i);
-    }
-    v_op(
-        lhs.as_slice(),
-        rhs.as_slice(),
-        result.as_mut_slice(),
-        sew,
-        lmul,
-        avl,
-    );
-
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-        let left = &lhs[range.clone()];
-        let right = &rhs[range.clone()];
-
-        let res = get_bit_in_slice(result.as_slice(), i);
-        let exp = get_bit_in_slice(expected.as_slice(), i);
-        if res != exp {
-            log!(
-                "[sew = {}, describe = {}] unexpected values found at index {} (nth-element): {:?} (result) {:?} (expected)",
-                sew, desc, i, res, exp
-            );
-            log!(
-                "more information, lhs = {:?}, rhs = {:?}, lmul = {}, avl = {}",
-                left,
-                right,
-                lmul,
-                avl
-            );
-            panic!("Abort");
-        }
-    }
-    if is_verbose() {
-        log!("finished");
-    }
-}
-
-pub fn run_vmsop_vx<T1, T2>(
-    sew: u64,
-    lmul: i64,
-    avl: u64,
-    mut expected_op: T1,
-    mut v_op: T2,
-    _: WideningCategory,
-    desc: &str,
-) where
-    T1: FnMut(&[u8], u64, &mut [u8], usize),
-    T2: FnMut(&[u8], u64, &mut [u8], u64, i64, u64),
-{
-    if is_verbose() {
-        log!(
-            "run with sew = {}, lmul = {}, avl = {}, desc = {}",
-            sew,
-            lmul,
-            avl,
-            desc
-        );
-    }
-    let vl = vsetvl(avl as u64, sew, lmul);
-    if vl == 0 {
-        return;
-    }
-
-    let avl_bytes = (sew / 8 * avl) as usize;
-    let sew_bytes = (sew / 8) as usize;
-
-    let mut lhs = Vec::<u8>::new();
-    lhs.resize(avl_bytes, 0);
-
-    let mut expected = Vec::<u8>::new();
-    let mut result = Vec::<u8>::new();
-
-    let result_avl_bytes = ceiling(avl as usize, 8);
-    result.resize(result_avl_bytes, 0);
-    expected.resize(result_avl_bytes, 0);
-
-    let mut rng = BestNumberRng::default();
-    let x = rng.next_u64();
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-
-        rng.fill(&mut lhs[range.clone()]);
-
-        expected_op(&lhs[range.clone()], x, &mut expected, i);
-    }
-    v_op(lhs.as_slice(), x, result.as_mut_slice(), sew, lmul, avl);
-
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-        let left = &lhs[range.clone()];
-        let right = x;
-
-        let res = get_bit_in_slice(result.as_slice(), i);
-        let exp = get_bit_in_slice(expected.as_slice(), i);
-        if res != exp {
-            log!(
-                "[sew = {}, describe = {}] unexpected values found at index {} (nth-element): {:?} (result) {:?} (expected)",
-                sew, desc, i, res, exp
-            );
-            log!(
-                "more information, lhs = {:0>2X?}, rhs = {:?}, lmul = {}, avl = {}",
-                left,
-                right,
-                lmul,
-                avl
-            );
-            panic!("Abort");
-        }
-    }
-    if is_verbose() {
-        log!("finished");
-    }
-}
-
-pub fn run_vmsop_vi<T1, T2>(
-    sew: u64,
-    lmul: i64,
-    avl: u64,
-    imm: i64,
-    mut expected_op: T1,
-    mut v_op: T2,
-    _: WideningCategory,
-    desc: &str,
-) where
-    T1: FnMut(&[u8], i64, &mut [u8], usize),
-    T2: FnMut(&[u8], i64, &mut [u8], u64, i64, u64),
-{
-    if is_verbose() {
-        log!(
-            "run with sew = {}, lmul = {}, avl = {}, desc = {}",
-            sew,
-            lmul,
-            avl,
-            desc
-        );
-    }
-    let vl = vsetvl(avl as u64, sew, lmul);
-    if vl == 0 {
-        return;
-    }
-
-    let avl_bytes = (sew / 8 * avl) as usize;
-    let sew_bytes = (sew / 8) as usize;
-
-    let mut lhs = Vec::<u8>::new();
-    lhs.resize(avl_bytes, 0);
-
-    let mut expected = Vec::<u8>::new();
-    let mut result = Vec::<u8>::new();
-
-    let result_avl_bytes = ceiling(avl as usize, 8);
-    result.resize(result_avl_bytes, 0);
-    expected.resize(result_avl_bytes, 0);
-
-    let mut rng = BestNumberRng::default();
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-
-        rng.fill(&mut lhs[range.clone()]);
-
-        expected_op(&lhs[range.clone()], imm, &mut expected, i);
-    }
-    v_op(lhs.as_slice(), imm, result.as_mut_slice(), sew, lmul, avl);
-
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-        let left = &lhs[range.clone()];
-
-        let res = get_bit_in_slice(result.as_slice(), i);
-        let exp = get_bit_in_slice(expected.as_slice(), i);
-        if res != exp {
-            log!(
-                "[sew = {}, describe = {}] unexpected values found at index {} (nth-element): {:?} (result) {:?} (expected)",
-                sew, desc, i, res, exp
-            );
-            log!(
-                "more information, lhs = {:0>2X?}, rhs = {:?}, lmul = {}, avl = {}",
-                left,
-                imm,
-                lmul,
-                avl
-            );
-            panic!("Abort");
-        }
-    }
-    if is_verbose() {
-        log!("finished");
-    }
-}
-
-pub fn run_vop_vx<T1, T2>(
-    sew: u64,
-    lmul: i64,
-    avl: u64,
-    mut expected_op: T1,
-    mut v_op: T2,
-    cat: WideningCategory,
-    desc: &str,
-) where
-    T1: FnMut(&[u8], u64, &mut [u8]),
-    T2: FnMut(&[u8], u64, &mut [u8], u64, i64, u64),
-{
-    if is_verbose() {
-        log!(
-            "run with sew = {}, lmul = {}, avl = {}, desc = {}",
-            sew,
-            lmul,
-            avl,
-            desc
-        );
-    }
-
-    let avl_bytes = (sew / 8 * avl) as usize;
-    let sew_bytes = (sew / 8) as usize;
-    let mut lhs = Vec::<u8>::new();
-    let mut expected = Vec::<u8>::new();
-    let mut result = Vec::<u8>::new();
-
-    match cat {
-        WideningCategory::VdVs2 => {
-            expected.resize(avl_bytes * 2, 0);
-            result.resize(avl_bytes * 2, 0);
-            lhs.resize(avl_bytes * 2, 0);
-        }
-        WideningCategory::VdOnly => {
-            expected.resize(avl_bytes * 2, 0);
-            result.resize(avl_bytes * 2, 0);
-            lhs.resize(avl_bytes, 0);
-        }
-        WideningCategory::Vs2Only => {
-            expected.resize(avl_bytes, 0);
-            result.resize(avl_bytes, 0);
-            lhs.resize(avl_bytes * 2, 0);
-        }
-        _ => {
-            expected.resize(avl_bytes, 0);
-            result.resize(avl_bytes, 0);
-            lhs.resize(avl_bytes, 0);
-        }
-    }
-
-    let mut rng = BestNumberRng::default();
-    let x = rng.next_u64();
-
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-        let lhs_range = match cat {
-            WideningCategory::VdVs2 => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            WideningCategory::Vs2Only => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            _ => range.clone(),
-        };
-        let expected_range = match cat {
-            WideningCategory::VdVs2 | WideningCategory::VdOnly => {
-                i * sew_bytes * 2..(i + 1) * sew_bytes * 2
-            }
-            _ => range.clone(),
-        };
-        rng.fill(&mut lhs[lhs_range.clone()]);
-        expected_op(
-            &lhs[lhs_range.clone()],
-            x,
-            &mut expected[expected_range.clone()],
-        );
-    }
-
-    v_op(lhs.as_slice(), x, result.as_mut_slice(), sew, lmul, avl);
-
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-
-        let expected_range = match cat {
-            WideningCategory::VdVs2 | WideningCategory::VdOnly => {
-                i * sew_bytes * 2..(i + 1) * sew_bytes * 2
-            }
-            _ => range.clone(),
-        };
-        let lhs_range = match cat {
-            WideningCategory::VdVs2 => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            WideningCategory::Vs2Only => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            _ => range.clone(),
-        };
-
-        let left = &lhs[lhs_range.clone()];
-        let right = x;
-
-        let res = &result[expected_range.clone()];
-        let exp = &expected[expected_range.clone()];
-        if res != exp {
-            log!(
-                "[sew = {}, describe = {}] unexpected values found at index {} (nth-element): {:0>2X?} (result) {:0>2X?} (expected)",
-                sew, desc, i, res, exp
-            );
-            log!(
-                "more information, lhs = {:0>2X?}, rhs = {:0>2X?}, lmul = {}, avl = {}",
-                left,
-                right,
-                lmul,
-                avl
-            );
-            panic!("Abort");
-        }
-    }
-    if is_verbose() {
-        log!("finished");
-    }
-}
-
-pub fn run_vop_vi<T1, T2>(
-    sew: u64,
-    lmul: i64,
-    avl: u64,
-    imm: i64,
-    mut expected_op: T1,
-    mut v_op: T2,
-    cat: WideningCategory,
-    desc: &str,
-) where
-    T1: FnMut(&[u8], i64, &mut [u8]),
-    T2: FnMut(&[u8], i64, &mut [u8], u64, i64, u64),
-{
-    if is_verbose() {
-        log!(
-            "run with sew = {}, lmul = {}, avl = {}, desc = {}",
-            sew,
-            lmul,
-            avl,
-            desc
-        );
-    }
-
-    let avl_bytes = (sew / 8 * avl) as usize;
-    let sew_bytes = (sew / 8) as usize;
-    let mut lhs = Vec::<u8>::new();
-    let mut expected = Vec::<u8>::new();
-    let mut result = Vec::<u8>::new();
-
-    match cat {
-        WideningCategory::VdVs2 => {
-            expected.resize(avl_bytes * 2, 0);
-            result.resize(avl_bytes * 2, 0);
-            lhs.resize(avl_bytes * 2, 0);
-        }
-        WideningCategory::VdOnly => {
-            expected.resize(avl_bytes * 2, 0);
-            result.resize(avl_bytes * 2, 0);
-            lhs.resize(avl_bytes, 0);
-        }
-        WideningCategory::Vs2Only => {
-            expected.resize(avl_bytes, 0);
-            result.resize(avl_bytes, 0);
-            lhs.resize(avl_bytes * 2, 0);
-        }
-        _ => {
-            expected.resize(avl_bytes, 0);
-            result.resize(avl_bytes, 0);
-            lhs.resize(avl_bytes, 0);
-        }
-    }
-
-    let mut rng = BestNumberRng::default();
-
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-        let lhs_range = match cat {
-            WideningCategory::VdVs2 => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            WideningCategory::Vs2Only => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            _ => range.clone(),
-        };
-        let expected_range = match cat {
-            WideningCategory::VdVs2 | WideningCategory::VdOnly => {
-                i * sew_bytes * 2..(i + 1) * sew_bytes * 2
-            }
-            _ => range.clone(),
-        };
-        rng.fill(&mut lhs[lhs_range.clone()]);
-        expected_op(
-            &lhs[lhs_range.clone()],
-            imm,
-            &mut expected[expected_range.clone()],
-        );
-    }
-
-    v_op(lhs.as_slice(), imm, result.as_mut_slice(), sew, lmul, avl);
-
-    for i in 0..avl as usize {
-        let range = i * sew_bytes..(i + 1) * sew_bytes;
-
-        let expected_range = match cat {
-            WideningCategory::VdVs2 | WideningCategory::VdOnly => {
-                i * sew_bytes * 2..(i + 1) * sew_bytes * 2
-            }
-            _ => range.clone(),
-        };
-        let lhs_range = match cat {
-            WideningCategory::VdVs2 => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            WideningCategory::Vs2Only => i * sew_bytes * 2..(i + 1) * sew_bytes * 2,
-            _ => range.clone(),
-        };
-
-        let left = &lhs[lhs_range.clone()];
-
-        let res = &result[expected_range.clone()];
-        let exp = &expected[expected_range.clone()];
-        if res != exp {
-            log!(
-                "[sew = {}, describe = {}] unexpected values found at index {} (nth-element): {:0>2X?} (result) {:0>2X?} (expected)",
-                sew, desc, i, res, exp
-            );
-            log!(
-                "more information, lhs = {:0>2X?}, rhs = {:0>2X?}, lmul = {}, avl = {}",
-                left,
-                imm,
-                lmul,
-                avl
-            );
-            panic!("Abort");
-        }
-    }
-    if is_verbose() {
-        log!("finished");
-    }
-}
-
 #[derive(Clone, Copy, PartialEq)]
 pub enum InstructionArgsType {
     Vector,
     Vector2,
     VectorBit,
+    VectorAlway16,
+    VectorRed,
+    VectorRed2,
+    VectorNarrow2,
+    VectorNarrow4,
+    VectorNarrow8,
     Scalar,
     Immediate,
     UImmediate,
     None,
+}
+
+impl Display for InstructionArgsType {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match self {
+            InstructionArgsType::Vector => write!(f, "vector"),
+            InstructionArgsType::Vector2 => write!(f, "vector2"),
+            InstructionArgsType::VectorBit => write!(f, "vector_bit"),
+            InstructionArgsType::VectorAlway16 => write!(f, "vector_alway16"),
+            InstructionArgsType::VectorRed => write!(f, "vector_red"),
+            InstructionArgsType::VectorRed2 => write!(f, "vector_red2"),
+            InstructionArgsType::VectorNarrow2 => write!(f, "vector_n2"),
+            InstructionArgsType::VectorNarrow4 => write!(f, "vector_n4"),
+            InstructionArgsType::VectorNarrow8 => write!(f, "vector_n8"),
+            InstructionArgsType::Scalar => write!(f, "scalar"),
+            InstructionArgsType::Immediate => write!(f, "immediate"),
+            InstructionArgsType::UImmediate => write!(f, "uimmediate"),
+            InstructionArgsType::None => write!(f, "none"),
+        }
+    }
+}
+
+impl InstructionArgsType {
+    fn is_imm(&self) -> bool {
+        *self == InstructionArgsType::Immediate || *self == InstructionArgsType::UImmediate
+    }
+
+    fn get_buf_len(&self, sew_byte: usize, vl: usize) -> usize {
+        match *self {
+            InstructionArgsType::None => 1 * sew_byte,
+            InstructionArgsType::Vector => vl * sew_byte,
+            InstructionArgsType::Vector2 => vl * 2 * sew_byte,
+            InstructionArgsType::VectorBit => vl * sew_byte,
+            InstructionArgsType::VectorAlway16 => vl * 2 , // The minimum sew is 8, sew * 2 >= 16
+            InstructionArgsType::VectorRed => vl * sew_byte,
+            InstructionArgsType::VectorRed2 => vl * 2 * sew_byte,
+            InstructionArgsType::VectorNarrow2 => vl * sew_byte / 2,
+            InstructionArgsType::VectorNarrow4 => vl * sew_byte / 4,
+            InstructionArgsType::VectorNarrow8 => vl * sew_byte / 8,
+            _ => 8,
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -918,7 +148,17 @@ pub enum MaskType {
     AsParam,
 }
 
-pub struct ExpectedParam {
+impl Display for MaskType {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match self {
+            MaskType::Disable => write!(f, "disable"),
+            MaskType::Enable => write!(f, "enable"),
+            MaskType::AsParam => write!(f, "as_param"),
+        }
+    }
+}
+
+pub struct RVVTestData {
     pub lhs: Vec<u8>,
     pub lhs_type: InstructionArgsType,
     pub rhs: Vec<u8>,
@@ -926,7 +166,9 @@ pub struct ExpectedParam {
     pub mask: Vec<u8>,
     pub mask_type: MaskType,
 
-    pub res: Vec<u8>,
+    pub res_before: Vec<u8>,
+    pub res_rvv: Vec<u8>,
+    pub res_exp: Vec<u8>,
     pub res_type: InstructionArgsType,
 
     pub sew_bytes: usize,
@@ -942,132 +184,165 @@ pub struct ExpectedParam {
 
 #[derive(Clone, Copy)]
 enum VectorCallbackType {
-    None(fn(&mut ExpectedParam)),
-    VV(fn(&mut [u8], &[u8], &[u8])),
-    VX(fn(&mut [u8], &[u8], u64)),
-    VI(fn(&mut [u8], &[u8], i64)),
-    VVM(fn(&mut [u8], &[u8], &[u8], bool)),
-    VXM(fn(&mut [u8], &[u8], u64, bool)),
-    VIM(fn(&mut [u8], &[u8], i64, bool)),
-    MVVM(fn(&mut bool, &[u8], &[u8], bool)),
-    MVXM(fn(&mut bool, &[u8], u64, bool)),
-    MVIM(fn(&mut bool, &[u8], i64, bool)),
-    MVV(fn(&mut bool, &[u8], &[u8])),
-    MVX(fn(&mut bool, &[u8], u64)),
-    MVI(fn(&mut bool, &[u8], i64)),
+    None(fn(&mut RVVTestData)),
+    VV(fn(&[u8], &[u8], &mut [u8])),
+    VX(fn(&[u8], u64, &mut [u8])),
+    VI(fn(&[u8], i64, &mut [u8])),
+    VVM(fn(&[u8], &[u8], &mut [u8], bool)),
+    VXM(fn(&[u8], u64, &mut [u8], bool)),
+    VIM(fn(&[u8], i64, &mut [u8], bool)),
+    MVVM(fn(&[u8], &[u8], &mut bool, bool)),
+    MVXM(fn(&[u8], u64, &mut bool, bool)),
+    MVIM(fn(&[u8], i64, &mut bool, bool)),
+    MVV(fn(&[u8], &[u8], &mut bool)),
+    MVX(fn(&[u8], u64, &mut bool)),
+    MVI(fn(&[u8], i64, &mut bool)),
+    MMM(fn(bool, bool, &mut bool)),
+    VVR(fn(&[u8], &[u8], &mut [u8], usize)),
 }
 
-struct RunOpConfig {
-    pub sew: u64,
-    pub lmul: i64,
-    pub avl: u64,
-    pub mask_type: MaskType,
-    pub expected_op_ext: VectorCallbackType,
-    pub v_op: fn(&[u8], &[u8], MaskType),
-    pub vd_type: InstructionArgsType,
-    pub args1_type: InstructionArgsType,
-    pub args2_type: InstructionArgsType,
-    pub immediate_val: i64,
-}
-
-impl RunOpConfig {
-    fn get_args_len(t: InstructionArgsType, vl: usize) -> usize {
-        match t {
-            InstructionArgsType::None => 1,
-            InstructionArgsType::Vector => vl,
-            InstructionArgsType::Vector2 => vl * 2,
-            InstructionArgsType::VectorBit => vl,
-            _ => 8,
-        }
-    }
-
-    pub fn get_vd_len(&self, vl: usize) -> usize {
-        Self::get_args_len(self.vd_type, vl)
-    }
-
-    pub fn get_left_len(&self, vl: usize) -> usize {
-        Self::get_args_len(self.args1_type, vl)
-    }
-
-    pub fn get_right_len(&self, vl: usize) -> usize {
-        Self::get_args_len(self.args2_type, vl)
-    }
-}
-
-impl ExpectedParam {
-    fn new(config: &RunOpConfig, avl_bytes: usize) -> Self {
-        let mut d = ExpectedParam {
+impl RVVTestData {
+    fn new(
+        lhs_type: InstructionArgsType,
+        rhs_type: InstructionArgsType,
+        res_type: InstructionArgsType,
+        mask_type: MaskType,
+        sew: u64,
+        lmul: i64,
+        avl: u64,
+    ) -> Self {
+        let vl = vsetvl(avl, sew, lmul);
+        assert!(
+            vl != 0,
+            "vsetvl result {}, sew: {}, lmul {}, avl: {}",
+            vl,
+            sew,
+            lmul,
+            avl
+        );
+        RVVTestData {
             lhs: Vec::new(),
-            lhs_type: config.args1_type,
+            lhs_type,
             rhs: Vec::new(),
-            rhs_type: config.args2_type,
+            rhs_type,
             mask: Vec::new(),
-            mask_type: config.mask_type,
-            res: Vec::new(),
-            res_type: config.vd_type,
+            mask_type,
+            res_before: Vec::new(),
+            res_rvv: Vec::new(),
+            res_exp: Vec::new(),
+            res_type,
 
-            sew_bytes: config.sew as usize / 8,
+            sew_bytes: (sew / 8) as usize,
 
             index: 0,
 
-            sew: config.sew,
-            lmul: config.lmul,
-            avl: config.avl,
-            theoretically_vl: 0,
+            sew,
+            lmul,
+            avl,
+            theoretically_vl: vl as usize,
 
             count: 0,
-        };
-
-        let mut rng = BestNumberRng::default();
-        d.mask.resize(VLEN / 8, 0xFF);
-        rng.fill(d.mask.as_mut_slice());
-
-        d.lhs.resize(config.get_left_len(avl_bytes), 0);
-        if config.args1_type == InstructionArgsType::Immediate
-            || config.args1_type == InstructionArgsType::UImmediate
-        {
-            d.lhs.copy_from_slice(&config.immediate_val.to_le_bytes());
-        } else {
-            rng.fill(d.lhs.as_mut_slice());
         }
-
-        d.rhs.resize(config.get_right_len(avl_bytes), 0);
-        if config.args2_type == InstructionArgsType::Immediate
-            || config.args2_type == InstructionArgsType::UImmediate
-        {
-            d.rhs.copy_from_slice(&config.immediate_val.to_le_bytes());
-        } else {
-            rng.fill(d.rhs.as_mut_slice());
-        }
-
-        d.res.resize(config.get_vd_len(avl_bytes), 0);
-        rng.fill(d.res.as_mut_slice());
-
-        d
     }
 
-    pub fn get_data_by_sclice(
-        d: &[u8],
-        t: InstructionArgsType,
-        sew_bytes: usize,
-        index: usize,
-    ) -> Vec<u8> {
+    fn rng_fill(&mut self) {
+        let mut rng = BestNumberRng::default();
+
+        // mask
+        let mask_len = {
+            let len = (self.avl / 8 + 1) as usize;
+            if len < VLEN / 8 {
+                VLEN / 8
+            } else {
+                len
+            }
+        };
+        self.mask.resize(mask_len, 0xFF);
+        rng.fill(self.mask.as_mut_slice());
+
+        // lhs
+        let lhs_len = self.lhs_type.get_buf_len(self.sew_bytes, self.avl as usize);
+        self.lhs.resize(lhs_len, 0);
+        rng.fill(self.lhs.as_mut_slice());
+
+        // rhs
+        let rhs_len = self.rhs_type.get_buf_len(self.sew_bytes, self.avl as usize);
+        self.rhs.resize(rhs_len, 0);
+        rng.fill(self.rhs.as_mut_slice());
+
+        // res
+        let res_len = self.res_type.get_buf_len(self.sew_bytes, self.avl as usize);
+        self.res_before.resize(res_len, 0);
+        rng.fill(self.res_before.as_mut_slice());
+        self.res_rvv = self.res_before.clone();
+        self.res_exp = self.res_before.clone();
+    }
+
+    fn get_args_range(&self, t: InstructionArgsType, index: usize) -> Range<usize> {
+        match t {
+            InstructionArgsType::None => {
+                panic!("Can not get range for here")
+            }
+            InstructionArgsType::Vector => index * self.sew_bytes..(index + 1) * self.sew_bytes,
+            InstructionArgsType::Vector2 => {
+                index * self.sew_bytes * 2..(index + 1) * self.sew_bytes * 2
+            }
+            InstructionArgsType::VectorAlway16 => index * 2..(index + 1) * 2,
+            InstructionArgsType::VectorRed => {
+                let i = self.count * self.theoretically_vl;
+                i * self.sew_bytes..(i + 1) * self.sew_bytes
+            }
+            InstructionArgsType::VectorRed2 => {
+                let i = self.count * self.theoretically_vl;
+                i * self.sew_bytes * 2..(i + 1) * self.sew_bytes * 2
+            }
+            InstructionArgsType::VectorNarrow2 => {
+                ((index * self.sew_bytes) as f64 * 0.5) as usize
+                    ..(((index + 1) * self.sew_bytes) as f64 * 0.5) as usize
+            }
+            InstructionArgsType::VectorNarrow4 => {
+                ((index * self.sew_bytes) as f64 * 0.25) as usize
+                    ..(((index + 1) * self.sew_bytes) as f64 * 0.25) as usize
+            }
+            InstructionArgsType::VectorNarrow8 => {
+                ((index * self.sew_bytes) as f64 * 0.125) as usize
+                    ..(((index + 1) * self.sew_bytes) as f64 * 0.125) as usize
+            }
+            InstructionArgsType::VectorBit => {
+                panic!("VectorBit can not get range for here")
+            }
+            _ => 0..8,
+        }
+    }
+
+    fn get_data_by_slice(&self, d: &[u8], t: InstructionArgsType) -> Vec<u8> {
+        if t == InstructionArgsType::VectorBit {
+            let mut res = Vec::<u8>::new();
+            res.resize(1, 0);
+            res[0] = get_bit_in_slice(d, self.index);
+            res
+        } else {
+            d[self.get_args_range(t, self.index)].to_vec()
+        }
+    }
+
+    pub fn get_data(&self, d: &[u8], t: InstructionArgsType, index: usize) -> Vec<u8> {
         if t == InstructionArgsType::VectorBit {
             let mut res = Vec::<u8>::new();
             res.resize(1, 0);
             res[0] = get_bit_in_slice(d, index);
             res
         } else {
-            d[get_args_range(t, sew_bytes, index)].to_vec()
+            d[self.get_args_range(t, index)].to_vec()
         }
     }
 
     pub fn get_left(&self) -> Vec<u8> {
-        Self::get_data_by_sclice(&self.lhs, self.lhs_type, self.sew_bytes, self.index)
+        self.get_data_by_slice(&self.lhs, self.lhs_type)
     }
 
     pub fn get_right(&self) -> Vec<u8> {
-        Self::get_data_by_sclice(&self.rhs, self.rhs_type, self.sew_bytes, self.index)
+        self.get_data_by_slice(&self.rhs, self.rhs_type)
     }
 
     pub fn get_right_u64(&self) -> u64 {
@@ -1078,112 +353,167 @@ impl ExpectedParam {
         u64::from_le_bytes(self.get_right().try_into().unwrap())
     }
 
-    pub fn get_result(&self) -> Vec<u8> {
-        Self::get_data_by_sclice(&self.res, self.res_type, self.sew_bytes, self.index)
+    fn get_result_befor(&self) -> Vec<u8> {
+        self.get_data_by_slice(&self.res_before, self.res_type)
     }
 
-    pub fn set_result(&mut self, data: &[u8]) {
-        let r = get_args_range(self.res_type, self.sew_bytes, self.index);
+    fn get_result_rvv(&self) -> Vec<u8> {
+        self.get_data_by_slice(&self.res_rvv, self.res_type)
+    }
+
+    fn get_result_exp(&self) -> Vec<u8> {
+        self.get_data_by_slice(&self.res_exp, self.res_type)
+    }
+
+    pub fn set_result_exp(&mut self, data: &[u8]) {
+        let r = self.get_args_range(self.res_type, self.index);
         if data.len() != r.len() {
             panic!("set_result data len is ne: {}, {}", data.len(), r.len());
         }
-        self.res[r].copy_from_slice(data);
+        self.res_exp[r].copy_from_slice(data);
     }
 
-    pub fn get_mask(&self) -> bool {
+    fn get_mask(&self) -> bool {
         match self.mask_type {
-            MaskType::Enable => {
-                get_bit_in_slice(&self.mask, self.index % self.theoretically_vl) == 1
-            }
-            MaskType::AsParam => {
-                get_bit_in_slice(&self.mask, self.index % self.theoretically_vl) == 1
-            }
+            MaskType::Enable => get_bit_in_slice(&self.mask, self.index) == 1,
+            MaskType::AsParam => get_bit_in_slice(&self.mask, self.index) == 1,
             MaskType::Disable => true,
         }
     }
 
-    pub fn get_rvv_left(&self) -> &[u8] {
-        if self.lhs_type == InstructionArgsType::Immediate
-            || self.lhs_type == InstructionArgsType::UImmediate
-            || self.lhs_type == InstructionArgsType::Scalar
+    fn get_rvv_slice(&self, buf: &[u8], buf_type: InstructionArgsType) -> Vec<u8> {
+        if buf_type == InstructionArgsType::Immediate
+            || buf_type == InstructionArgsType::UImmediate
+            || buf_type == InstructionArgsType::Scalar
         {
-            self.lhs.as_slice()
-        } else {
-            let vl =
-                RunOpConfig::get_args_len(self.lhs_type, self.theoretically_vl) * self.sew_bytes;
+            buf.to_vec()
+        } else if buf_type == InstructionArgsType::VectorBit {
+            let vl = buf_type.get_buf_len(self.sew_bytes, self.theoretically_vl);
 
+            let begin = vl * self.count / self.sew_bytes;
+            let mut end = vl * (self.count + 1) / self.sew_bytes;
+
+            assert!(begin < end, "Abort begin: {} < end: {}", begin, end);
+
+            if end > buf.len() * 8 / self.sew_bytes {
+                end = buf.len() * 8 / self.sew_bytes;
+            }
+            let buf_len = end - begin;
+            let buf_len = buf_len / 8 + if buf_len % 8 != 0 { 1 } else { 0 };
+            let mut ret_buf = Vec::<u8>::new();
+            ret_buf.resize(buf_len, 0);
+            for i in begin..end {
+                set_bit_in_slice(&mut ret_buf, i - begin, get_bit_in_slice(buf, i));
+            }
+
+            ret_buf
+        } else {
+            let vl = buf_type.get_buf_len(self.sew_bytes, self.theoretically_vl);
             let begin = vl * self.count;
             let mut end = vl * (self.count + 1);
-            if end > self.lhs.len() {
-                end = self.lhs.len();
+            assert!(begin < end, "Abort begin: {} < end: {}", begin, end);
+            if end > buf.len() {
+                end = buf.len();
             }
-            &self.lhs[begin..end]
+            dbg_log!("------type: {}, begin: {}, end: {}", buf_type, begin, end);
+            buf[begin..end].to_vec()
         }
     }
 
-    pub fn get_rvv_right(&self) -> &[u8] {
-        if self.rhs_type == InstructionArgsType::Immediate
-            || self.rhs_type == InstructionArgsType::UImmediate
-            || self.rhs_type == InstructionArgsType::Scalar
-        {
-            self.rhs.as_slice()
-        } else {
-            let vl =
-                RunOpConfig::get_args_len(self.rhs_type, self.theoretically_vl) * self.sew_bytes;
-
-            let begin = vl * self.count;
-            let mut end = vl * (self.count + 1);
-            if end > self.rhs.len() {
-                end = self.rhs.len();
-            }
-
-            &self.rhs[begin..end]
-        }
+    fn get_rvv_left(&self) -> Vec<u8> {
+        self.get_rvv_slice(self.lhs.as_slice(), self.lhs_type)
     }
 
-    pub fn get_rvv_result_range(&self) -> Range<usize> {
+    fn get_rvv_right(&self) -> Vec<u8> {
+        self.get_rvv_slice(self.rhs.as_slice(), self.rhs_type)
+    }
+
+    fn get_rvv_result(&self, buf: &[u8]) -> Vec<u8> {
+        self.get_rvv_slice(buf, self.res_type)
+    }
+
+    fn set_rvv_result(&mut self, src: &[u8]) {
         if self.res_type == InstructionArgsType::Immediate
             || self.res_type == InstructionArgsType::UImmediate
             || self.res_type == InstructionArgsType::Scalar
         {
-            0..self.res.len()
+            self.res_rvv.copy_from_slice(src);
+        } else if self.res_type == InstructionArgsType::VectorBit {
+            let vl = self
+                .res_type
+                .get_buf_len(self.sew_bytes, self.theoretically_vl);
+
+            let begin = vl * self.count / self.sew_bytes;
+            let mut end = vl * (self.count + 1) / self.sew_bytes;
+            if end > self.res_rvv.len() / self.sew_bytes {
+                end = self.res_rvv.len() / self.sew_bytes;
+            }
+            assert!(begin < end);
+            for i in begin..end {
+                set_bit_in_slice(
+                    self.res_rvv.as_mut_slice(),
+                    i,
+                    get_bit_in_slice(src, i - begin),
+                );
+            }
         } else {
-            let vl =
-                RunOpConfig::get_args_len(self.res_type, self.theoretically_vl) * self.sew_bytes;
+            let vl = self
+                .res_type
+                .get_buf_len(self.sew_bytes, self.theoretically_vl);
 
             let begin = vl * self.count;
             let mut end = vl * (self.count + 1);
-            if end > self.res.len() {
-                end = self.res.len();
+            if end > self.res_rvv.len() {
+                end = self.res_rvv.len();
             }
-
-            begin..end
+            dbg_log!("-------- begin: {}, end: {}, vl: {}", begin, end, vl);
+            self.res_rvv[begin..end].copy_from_slice(src);
         }
+    }
+
+    fn get_rvv_mask(&self) -> Vec<u8> {
+        self.get_rvv_slice(&self.mask, InstructionArgsType::VectorBit)
     }
 
     fn get_sew(sew: u64, t: InstructionArgsType) -> u64 {
         match t {
             InstructionArgsType::Vector2 => sew * 2,
+            InstructionArgsType::VectorAlway16 => 16,
+            InstructionArgsType::VectorRed2 => sew * 2,
+            InstructionArgsType::VectorNarrow2 => (sew as f64 * 0.5) as u64,
+            InstructionArgsType::VectorNarrow4 => (sew as f64 * 0.25) as u64,
+            InstructionArgsType::VectorNarrow8 => (sew as f64 * 0.125) as u64,
             _ => sew,
         }
     }
 
     fn get_left_sew(&self, sew: u64) -> u64 {
-        ExpectedParam::get_sew(sew, self.lhs_type)
+        RVVTestData::get_sew(sew, self.lhs_type)
     }
 
     fn get_right_sew(&self, sew: u64) -> u64 {
-        ExpectedParam::get_sew(sew, self.rhs_type)
+        RVVTestData::get_sew(sew, self.rhs_type)
     }
 
     fn get_result_sew(&self, sew: u64) -> u64 {
-        ExpectedParam::get_sew(sew, self.res_type)
+        RVVTestData::get_sew(sew, self.res_type)
     }
 
     pub fn get_vl(&self) -> usize {
         let total_vl = match self.res_type {
-            InstructionArgsType::Vector => self.res.len() / self.sew_bytes,
-            InstructionArgsType::Vector2 => self.res.len() / self.sew_bytes / 2,
+            InstructionArgsType::Vector => self.res_before.len() / self.sew_bytes,
+            InstructionArgsType::Vector2 => self.res_before.len() / self.sew_bytes / 2,
+            InstructionArgsType::VectorRed => self.res_before.len() / self.sew_bytes,
+            InstructionArgsType::VectorRed2 => self.res_before.len() / self.sew_bytes / 2,
+            InstructionArgsType::VectorNarrow2 => {
+                ((self.res_before.len() / self.sew_bytes) as f64 / 0.5) as usize
+            }
+            InstructionArgsType::VectorNarrow4 => {
+                ((self.res_before.len() / self.sew_bytes) as f64 / 0.25) as usize
+            }
+            InstructionArgsType::VectorNarrow8 => {
+                ((self.res_before.len() / self.sew_bytes) as f64 / 0.125) as usize
+            }
             _ => panic!("Abort"),
         };
 
@@ -1201,284 +531,340 @@ impl ExpectedParam {
             rem
         }
     }
-}
 
-fn get_args_range(t: InstructionArgsType, sew_bytes: usize, index: usize) -> Range<usize> {
-    match t {
-        InstructionArgsType::None => {
-            panic!("Can not get range for here")
+    fn get_lmul(lmul: i64) -> f64 {
+        match lmul {
+            -8 => 0.125,
+            -4 => 0.25,
+            -2 => 0.5,
+            1 => 1.0,
+            2 => 2.0,
+            4 => 4.0,
+            8 => 8.0,
+            _ => panic!("Abort"),
         }
-        InstructionArgsType::Vector => index * sew_bytes..(index + 1) * sew_bytes,
-        InstructionArgsType::Vector2 => index * sew_bytes * 2..(index + 1) * sew_bytes * 2,
-        InstructionArgsType::VectorBit => {
-            panic!("VectorBit can not get range for here")
-        }
-        _ => 0..8,
+    }
+
+    fn get_rvv_index(&self) -> usize {
+        self.index % self.theoretically_vl
     }
 }
 
-fn clean_v() {
-    
-}
-
-fn run_rvv_op(exp_param: &mut ExpectedParam, res: &mut [u8], op: fn(&[u8], &[u8], MaskType)) {
+fn run_rvv_op(rvv_data: &mut RVVTestData, op: fn(&[u8], &[u8], MaskType)) {
     let empty_buf = [0u8; 1];
 
-    let mut avl = exp_param.avl as i64;
-    let sew = exp_param.sew;
-    let mask_type = exp_param.mask_type;
+    let mut avl = rvv_data.avl as i64;
+    let sew = rvv_data.sew;
+    let mask_type = rvv_data.mask_type;
 
-    exp_param.count = 0;
+    rvv_data.count = 0;
     while avl > 0 {
-        let vl = vsetvl(avl as u64, exp_param.sew, exp_param.lmul) as usize;
+        dbg_log!("----r_rvv 1");
+        let vl = vsetvl(avl as u64, rvv_data.sew, rvv_data.lmul) as usize;
         if vl == 0 {
             panic!("Abort")
         }
+        dbg_log!("----r_rvv 2");
         avl -= vl as i64;
 
-        clean_v();
-
-        let l = if exp_param.lhs_type == InstructionArgsType::Immediate
-            || exp_param.lhs_type == InstructionArgsType::UImmediate
-            || exp_param.lhs_type == InstructionArgsType::Scalar
+        dbg_log!(
+            "----r_rvv 3, lhs_type: {}, lhs: {:0>2X?}",
+            rvv_data.lhs_type,
+            rvv_data.get_rvv_left()
+        );
+        let l = if rvv_data.lhs_type == InstructionArgsType::Immediate
+            || rvv_data.lhs_type == InstructionArgsType::UImmediate
+            || rvv_data.lhs_type == InstructionArgsType::Scalar
         {
-            exp_param.lhs.as_slice()
+            rvv_data.lhs.as_slice()
         } else {
             clean_cache_v8();
-            vle_v8(exp_param.get_left_sew(sew), &exp_param.get_rvv_left());
+            vle_v8(rvv_data.get_left_sew(sew), &rvv_data.get_rvv_left());
             &empty_buf
         };
 
-        let r = if exp_param.rhs_type == InstructionArgsType::Immediate
-            || exp_param.rhs_type == InstructionArgsType::UImmediate
-            || exp_param.rhs_type == InstructionArgsType::Scalar
+        dbg_log!(
+            "----r_rvv 4, rhs_type: {}, rhs: {:0>2X?}",
+            rvv_data.rhs_type,
+            rvv_data.get_rvv_right()
+        );
+        let r = if rvv_data.rhs_type == InstructionArgsType::Immediate
+            || rvv_data.rhs_type == InstructionArgsType::UImmediate
+            || rvv_data.rhs_type == InstructionArgsType::Scalar
         {
-            exp_param.rhs.as_slice()
+            rvv_data.rhs.as_slice()
         } else {
             clean_cache_v16();
-            vle_v16(exp_param.get_right_sew(sew), exp_param.get_rvv_right());
+            vle_v16(rvv_data.get_right_sew(sew), &rvv_data.get_rvv_right());
             &empty_buf
         };
 
         if mask_type == MaskType::Enable || mask_type == MaskType::AsParam {
-            vl1r_v0(&exp_param.mask);
+            let mut buf = Vec::<u8>::new();
+            buf.resize(VLEN / 8, 0);
+            let mask = rvv_data.get_rvv_mask();
+            buf[..mask.len()].copy_from_slice(&mask);
+            dbg_log!("----r_rvv 5, mask: {:0>2X?}", buf);
+            vl1r_v0(&buf);
+        } else {
+            dbg_log!("----r_rvv 5");
         }
 
-        let res_range = exp_param.get_rvv_result_range();
-        vle_v24(exp_param.get_result_sew(sew), &res[res_range.clone()]);
-        op.clone()(l, r, mask_type);
-        vse_v24(exp_param.get_result_sew(sew), &mut res[res_range.clone()]);
+        let (mut result, result_len) = {
+            let d = rvv_data.get_rvv_result(&rvv_data.res_rvv);
+            if rvv_data.res_type == InstructionArgsType::VectorBit {
+                let mut buf = Vec::<u8>::new();
+                buf.resize(rvv_data.theoretically_vl * rvv_data.sew_bytes, 0);
 
-        exp_param.count += 1;
+                buf[..d.len()].copy_from_slice(&d);
+
+                (buf, d.len())
+            } else {
+                let dlen = d.len();
+                (d, dlen)
+            }
+        };
+        dbg_log!(
+            "----r_rvv 6, res type: {}, res: {:0>2X?}",
+            rvv_data.res_type,
+            &result[..result_len]
+        );
+        vle_v24(rvv_data.get_result_sew(sew), &result);
+        dbg_log!("----r_rvv 7");
+        op.clone()(l, r, mask_type);
+        dbg_log!("----r_rvv 8");
+        vse_v24(rvv_data.get_result_sew(sew), &mut result);
+
+        dbg_log!("----r_rvv 9, \nres1: {:0>2X?}", &result[..result_len]);
+        rvv_data.set_rvv_result(&result[..result_len]);
+
+        dbg_log!("----r_rvv 10, res: {:0>2X?}", rvv_data.res_rvv);
+
+        rvv_data.count += 1;
     }
 }
 
-fn run_op(config: &RunOpConfig, desc: &str) {
+fn run_op(
+    rvv_data: &mut RVVTestData,
+    rvv_op: fn(&[u8], &[u8], MaskType),
+    exp_op: VectorCallbackType,
+    masked_op: fn(&mut RVVTestData),
+    desc: &str,
+) {
     if is_verbose() {
         log!(
             "run with sew = {}, lmul = {}, avl = {}, desc = {}",
-            config.sew,
-            config.lmul,
-            config.avl,
+            rvv_data.sew,
+            rvv_data.lmul,
+            rvv_data.avl,
             desc
         );
     }
-    let vl = vsetvl(config.avl as u64, config.sew, config.lmul);
-    if vl == 0 {
-        return;
-    }
 
-    let avl_bytes = (config.sew / 8 * config.avl) as usize;
-    let sew_bytes = (config.sew / 8) as usize;
+    dbg_log!("--r 1");
 
-    let mut exp_param = ExpectedParam::new(config, avl_bytes);
-
-    exp_param.theoretically_vl = vl as usize;
-    let expected_before = exp_param.res.clone();
-    let mut result = exp_param.res.clone();
-    for i in 0..config.avl as usize {
-        exp_param.index = i;
-        exp_param.count = i / vl as usize;
-        if config.mask_type == MaskType::Enable && !exp_param.get_mask() {
+    for i in 0..rvv_data.avl as usize {
+        rvv_data.index = i;
+        rvv_data.count = i / rvv_data.theoretically_vl as usize;
+        if rvv_data.mask_type == MaskType::Enable && !rvv_data.get_mask() {
+            masked_op.clone()(rvv_data);
+            dbg_log!("--r 3, is mask, index: {}", i);
             continue;
         }
-        match config.expected_op_ext {
+        match exp_op {
             VectorCallbackType::None(op) => {
-                op(&mut exp_param);
+                op(rvv_data);
             }
             VectorCallbackType::VV(op) => {
-                let mut res = exp_param.get_result();
+                let mut res = rvv_data.get_result_befor();
                 op(
+                    rvv_data.get_left().as_slice(),
+                    rvv_data.get_right().as_slice(),
                     res.as_mut_slice(),
-                    exp_param.get_left().as_slice(),
-                    exp_param.get_right().as_slice(),
                 );
-                exp_param.set_result(&res);
+                dbg_log!(
+                        "--r 3, index: {}, lhs: {:0>2X?}, rhs: {:0>2X?}, res1: {:0>2X?}, res2: {:0>2X?}",
+                        i,
+                        rvv_data.get_left(),
+                        rvv_data.get_right(),
+                        rvv_data.get_result_befor(),
+                        res
+                    );
+
+                rvv_data.set_result_exp(&res);
             }
             VectorCallbackType::VX(op) => {
-                let mut res = exp_param.get_result();
+                let mut res = rvv_data.get_result_befor();
                 op(
+                    rvv_data.get_left().as_slice(),
+                    rvv_data.get_right_u64(),
                     res.as_mut_slice(),
-                    exp_param.get_left().as_slice(),
-                    exp_param.get_right_u64(),
                 );
-                exp_param.set_result(&res);
+                rvv_data.set_result_exp(&res);
             }
             VectorCallbackType::VI(op) => {
-                let mut res = exp_param.get_result();
+                let mut res = rvv_data.get_result_befor();
                 op(
+                    rvv_data.get_left().as_slice(),
+                    rvv_data.get_right_u64() as i64,
                     res.as_mut_slice(),
-                    exp_param.get_left().as_slice(),
-                    exp_param.get_right_u64() as i64,
                 );
-                exp_param.set_result(&res);
+                rvv_data.set_result_exp(&res);
             }
             VectorCallbackType::VVM(op) => {
-                let mut res = exp_param.get_result();
+                let mut res = rvv_data.get_result_befor();
                 op(
+                    rvv_data.get_left().as_slice(),
+                    rvv_data.get_right().as_slice(),
                     res.as_mut_slice(),
-                    exp_param.get_left().as_slice(),
-                    exp_param.get_right().as_slice(),
-                    exp_param.get_mask(),
+                    rvv_data.get_mask(),
                 );
-                exp_param.set_result(&res);
+                rvv_data.set_result_exp(&res);
             }
             VectorCallbackType::VXM(op) => {
-                let mut res = exp_param.get_result();
+                let mut res = rvv_data.get_result_befor();
                 op(
+                    rvv_data.get_left().as_slice(),
+                    rvv_data.get_right_u64(),
                     res.as_mut_slice(),
-                    exp_param.get_left().as_slice(),
-                    exp_param.get_right_u64(),
-                    exp_param.get_mask(),
+                    rvv_data.get_mask(),
                 );
-                exp_param.set_result(&res);
+                rvv_data.set_result_exp(&res);
             }
             VectorCallbackType::VIM(op) => {
-                let mut res = exp_param.get_result();
+                let mut res = rvv_data.get_result_befor();
                 op(
+                    rvv_data.get_left().as_slice(),
+                    rvv_data.get_right_u64() as i64,
                     res.as_mut_slice(),
-                    exp_param.get_left().as_slice(),
-                    exp_param.get_right_u64() as i64,
-                    exp_param.get_mask(),
+                    rvv_data.get_mask(),
                 );
-                exp_param.set_result(&res);
+                rvv_data.set_result_exp(&res);
             }
             VectorCallbackType::MVVM(op) => {
-                let index = exp_param.index as u64;
-                let pos = (config.sew * vl * (index / vl) + index % vl) as usize;
-
-                let mut res = get_bit_in_slice(&exp_param.res, pos) == 1;
+                let mut res = get_bit_in_slice(&rvv_data.res_before, i) == 1;
                 op(
+                    rvv_data.get_left().as_slice(),
+                    rvv_data.get_right().as_slice(),
                     &mut res,
-                    exp_param.get_left().as_slice(),
-                    exp_param.get_right().as_slice(),
-                    exp_param.get_mask(),
+                    rvv_data.get_mask(),
                 );
-                set_bit_in_slice(&mut exp_param.res, pos, res as u8);
+                set_bit_in_slice(&mut rvv_data.res_exp, i, res as u8);
             }
             VectorCallbackType::MVXM(op) => {
-                let index = exp_param.index as u64;
-                let pos = (config.sew * vl * (index / vl) + index % vl) as usize;
-
-                let mut res = get_bit_in_slice(&exp_param.res, pos) == 1;
+                let mut res = get_bit_in_slice(&rvv_data.res_before, i) == 1;
                 op(
+                    rvv_data.get_left().as_slice(),
+                    rvv_data.get_right_u64(),
                     &mut res,
-                    exp_param.get_left().as_slice(),
-                    exp_param.get_right_u64(),
-                    exp_param.get_mask(),
+                    rvv_data.get_mask(),
                 );
-                set_bit_in_slice(&mut exp_param.res, pos, res as u8);
+                set_bit_in_slice(&mut rvv_data.res_exp, i, res as u8);
             }
             VectorCallbackType::MVIM(op) => {
-                let index = exp_param.index as u64;
-                let pos = (config.sew * vl * (index / vl) + index % vl) as usize;
-
-                let mut res = get_bit_in_slice(&exp_param.res, pos) == 1;
+                let mut res = get_bit_in_slice(&rvv_data.res_before, i) == 1;
                 op(
+                    rvv_data.get_left().as_slice(),
+                    rvv_data.get_right_u64() as i64,
                     &mut res,
-                    exp_param.get_left().as_slice(),
-                    exp_param.get_right_u64() as i64,
-                    exp_param.get_mask(),
+                    rvv_data.get_mask(),
                 );
-                set_bit_in_slice(&mut exp_param.res, pos, res as u8);
+                set_bit_in_slice(&mut rvv_data.res_exp, i, res as u8);
             }
             VectorCallbackType::MVV(op) => {
-                let index = exp_param.index as u64;
-                let pos = (config.sew * vl * (index / vl) + index % vl) as usize;
-
-                let mut res = get_bit_in_slice(&exp_param.res, pos) == 1;
+                let mut res = get_bit_in_slice(&rvv_data.res_before, i) == 1;
                 op(
+                    rvv_data.get_left().as_slice(),
+                    rvv_data.get_right().as_slice(),
                     &mut res,
-                    exp_param.get_left().as_slice(),
-                    exp_param.get_right().as_slice(),
                 );
-                set_bit_in_slice(&mut exp_param.res, pos, res as u8);
+                set_bit_in_slice(&mut rvv_data.res_exp, i, res as u8);
             }
             VectorCallbackType::MVX(op) => {
-                let index = exp_param.index as u64;
-                let pos = (config.sew * vl * (index / vl) + index % vl) as usize;
-
-                let mut res = get_bit_in_slice(&exp_param.res, pos) == 1;
+                let mut res = get_bit_in_slice(&rvv_data.res_before, i) == 1;
                 op(
+                    rvv_data.get_left().as_slice(),
+                    rvv_data.get_right_u64(),
                     &mut res,
-                    exp_param.get_left().as_slice(),
-                    exp_param.get_right_u64(),
                 );
-                set_bit_in_slice(&mut exp_param.res, pos, res as u8);
+                set_bit_in_slice(&mut rvv_data.res_exp, i, res as u8);
             }
             VectorCallbackType::MVI(op) => {
-                let index = exp_param.index as u64;
-                let pos = (config.sew * vl * (index / vl) + index % vl) as usize;
-
-                let mut res = get_bit_in_slice(&exp_param.res, pos) == 1;
+                let mut res = get_bit_in_slice(&rvv_data.res_before, i) == 1;
                 op(
+                    rvv_data.get_left().as_slice(),
+                    rvv_data.get_right_u64() as i64,
                     &mut res,
-                    exp_param.get_left().as_slice(),
-                    exp_param.get_right_u64() as i64,
                 );
-                set_bit_in_slice(&mut exp_param.res, pos, res as u8);
+                set_bit_in_slice(&mut rvv_data.res_exp, i, res as u8);
+            }
+            VectorCallbackType::MMM(op) => {
+                let mut res = get_bit_in_slice(&rvv_data.res_before, i) == 1;
+                let lhs = get_bit_in_slice(&rvv_data.lhs, rvv_data.index) == 1;
+                let rhs = get_bit_in_slice(&rvv_data.rhs, rvv_data.index) == 1;
+
+                op(lhs, rhs, &mut res);
+                set_bit_in_slice(&mut rvv_data.res_exp, i, res as u8);
+            }
+            VectorCallbackType::VVR(op) => {
+                let mut res = rvv_data.get_result_exp();
+                let index = rvv_data.get_rvv_index();
+                op(
+                    rvv_data.get_left().as_slice(),
+                    rvv_data.get_right().as_slice(),
+                    res.as_mut_slice(),
+                    index,
+                );
+                rvv_data.set_result_exp(&res);
             }
         }
     }
 
-    run_rvv_op(&mut exp_param, result.as_mut_slice(), config.v_op);
+    dbg_log!("--r 4");
+    run_rvv_op(rvv_data, rvv_op);
+    dbg_log!("--r 5");
 
-    for i in 0..config.avl as usize {
-        exp_param.index = i;
-        let exp = exp_param.get_result();
-        let res = ExpectedParam::get_data_by_sclice(&result, config.vd_type, sew_bytes, i);
-        let exp_befor =
-            ExpectedParam::get_data_by_sclice(&expected_before, config.vd_type, sew_bytes, i);
+    for i in 0..rvv_data.avl as usize {
+        rvv_data.index = i;
+        rvv_data.count = i / rvv_data.theoretically_vl as usize;
+        let exp = rvv_data.get_result_exp();
+        let res = rvv_data.get_result_rvv();
+        let exp_befor = rvv_data.get_result_befor();
 
         if exp != res {
             log!(
                 "[sew = {}, describe = {}] unexpected values found at index {} \nresult = {:0>2X?} \nexpected = {:0>2X?}",
-                config.sew, desc, i, res, exp
+                rvv_data.sew, desc, i, res, exp
             );
             log!(
-                "more information, \nlhs = {:0>2X?} \nrhs = {:0>2X?} \nexpected_before = {:0>2X?}, \nlmul = {}, avl = {}",
-                exp_param.get_left(),
-                exp_param.get_right(),
-                exp_befor,
-                config.lmul,
-                config.avl
+                "more information, \nlhs = {:0>2X?} \nrhs = {:0>2X?} \nexpected_before = {:0>2X?}",
+                rvv_data.get_left(),
+                rvv_data.get_right(),
+                exp_befor
             );
-            //log!("more infomation, expected: {:0>2X?} \nresult: {:0>2X?} \nmask: {:0>2X?}", exp_param.res, result, exp_param.mask);
+
+            log!(
+                "-lmul = {}, avl = {}, vl = {}, mask = {}",
+                rvv_data.lmul,
+                rvv_data.avl,
+                rvv_data.theoretically_vl,
+                rvv_data.mask_type
+            );
+
+            log!("-expected: {:0>2X?}", rvv_data.res_exp);
+            log!("-result: {:0>2X?}", rvv_data.res_rvv);
+            log!("-res_before: {:0>2X?}", rvv_data.res_before);
+            if rvv_data.mask_type != MaskType::Disable {
+                log!("-mask = {:0>2X?}", &rvv_data.mask);
+            }
+            log!("-lhs: {:0>2X?}", rvv_data.lhs);
+            log!("-rhs: {:0>2X?}", rvv_data.rhs);
             panic!("Abort");
         }
     }
+    dbg_log!("--r 6");
     if is_verbose() {
         log!("finished");
-    }
-}
-
-fn get_imm_begin(l: InstructionArgsType, r: InstructionArgsType) -> i64 {
-    if l == InstructionArgsType::Immediate || r == InstructionArgsType::Immediate {
-        -16
-    } else if l == InstructionArgsType::UImmediate || r == InstructionArgsType::UImmediate {
-        0
-    } else {
-        0
     }
 }
 
@@ -1488,45 +874,77 @@ fn run_template_ext(
     right_type: InstructionArgsType,
     mask_type: MaskType,
     rvv_op: fn(&[u8], &[u8], MaskType),
-    callback: VectorCallbackType,
-    sews: &[u64],
-    lmuls: &[i64],
+    exp_op: VectorCallbackType,
+    before_op: fn(f64, f64, u64) -> bool,
+    masked_op: fn(&mut RVVTestData),
     desc: &str,
 ) {
+    fn get_imm_begin(l: InstructionArgsType, r: InstructionArgsType) -> i64 {
+        if l == InstructionArgsType::Immediate || r == InstructionArgsType::Immediate {
+            -16
+        } else if l == InstructionArgsType::UImmediate || r == InstructionArgsType::UImmediate {
+            0
+        } else {
+            0
+        }
+    }
+
     let mut enable_mask = true;
     let imm_begin = get_imm_begin(left_type, right_type);
     let mut imm = imm_begin;
+
+    let sews = &[64, 256];
+    let lmuls = &[-8, -4, -2, 1, 2, 4, 8];
+
     for sew in sews {
         for lmul in lmuls {
             for avl in avl_iterator(sew.clone(), 2) {
-                let mut config = RunOpConfig {
-                    sew: sew.clone(),
-                    lmul: lmul.clone(),
-                    avl,
-                    mask_type,
-                    expected_op_ext: callback,
-                    v_op: rvv_op,
-                    vd_type: vd_type,
-                    args1_type: left_type,
-                    args2_type: right_type,
-                    immediate_val: imm,
-                };
+                if vsetvl(avl, *sew, *lmul) == 0 {
+                    continue;
+                }
 
-                if mask_type == MaskType::Enable {
-                    config.mask_type = if enable_mask {
+                if !before_op.clone()(*sew as f64, RVVTestData::get_lmul(*lmul), avl) {
+                    continue;
+                }
+
+                let e_mask_type = if mask_type == MaskType::Enable {
+                    enable_mask = !enable_mask;
+                    if !enable_mask {
                         MaskType::Enable
                     } else {
                         MaskType::Disable
-                    };
-                    enable_mask = !enable_mask;
-                }
-                run_op(&config, desc);
+                    }
+                } else {
+                    mask_type
+                };
 
-                if left_type == InstructionArgsType::Immediate
-                    || right_type == InstructionArgsType::Immediate
-                    || left_type == InstructionArgsType::UImmediate
-                    || right_type == InstructionArgsType::UImmediate
-                {
+                let mut rvv_data = RVVTestData::new(
+                    left_type,
+                    right_type,
+                    vd_type,
+                    e_mask_type,
+                    sew.clone(),
+                    lmul.clone(),
+                    avl,
+                );
+                dbg_log!(
+                    "-sew: {}, lmul: {}, avl: {}, mask: {}",
+                    sew,
+                    lmul,
+                    avl,
+                    mask_type
+                );
+                rvv_data.rng_fill();
+                if left_type.is_imm() {
+                    rvv_data.lhs.copy_from_slice(&imm.to_le_bytes());
+                }
+                if right_type.is_imm() {
+                    rvv_data.rhs.copy_from_slice(&imm.to_le_bytes());
+                }
+
+                run_op(&mut rvv_data, rvv_op, exp_op, masked_op, desc);
+
+                if left_type.is_imm() || right_type.is_imm() {
                     imm += 1;
                     if imm == imm_begin + 32 {
                         imm = imm_begin
@@ -1537,15 +955,40 @@ fn run_template_ext(
     }
 }
 
+fn befor_op_default(_: f64, _: f64, _: u64) -> bool {
+    true
+}
+
+fn befor_op_wide(sew: f64, lmul: f64, _: u64) -> bool {
+    if sew * 2.0 > 1024.0 {
+        return false;
+    }
+    let emul = lmul * 2.0;
+    if emul >= 0.125 && emul <= 8.0 {
+        true
+    } else {
+        false
+    }
+}
+
+fn masked_op_default(_: &mut RVVTestData) {}
+
+fn masked_op_red(rvv_data: &mut RVVTestData) {
+    let index = rvv_data.get_rvv_index();
+    if index == 0 {
+        let rhs = rvv_data.get_right();
+        rvv_data.set_result_exp(&rhs);
+    }
+}
+
 pub fn run_template(
     vd_type: InstructionArgsType,
     left_type: InstructionArgsType,
     right_type: InstructionArgsType,
     mask_type: MaskType,
-    expected_op: fn(&mut ExpectedParam),
+    expected_op: fn(&mut RVVTestData),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
+    before_op: fn(f64, f64, u64) -> bool,
     desc: &str,
 ) {
     run_template_ext(
@@ -1555,17 +998,15 @@ pub fn run_template(
         mask_type,
         rvv_op,
         VectorCallbackType::None(expected_op),
-        sews,
-        lmuls,
+        before_op,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_vvm(
-    expected_op: fn(&mut [u8], &[u8], &[u8], bool),
+pub fn run_template_v_vvm(
+    expected_op: fn(&[u8], &[u8], &mut [u8], bool),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
     desc: &str,
 ) {
     run_template_ext(
@@ -1575,17 +1016,15 @@ pub fn run_template_vvm(
         MaskType::AsParam,
         rvv_op,
         VectorCallbackType::VVM(expected_op),
-        sews,
-        lmuls,
+        befor_op_default,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_vxm(
-    expected_op: fn(&mut [u8], &[u8], u64, bool),
+pub fn run_template_v_vxm(
+    expected_op: fn(&[u8], u64, &mut [u8], bool),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
     desc: &str,
 ) {
     run_template_ext(
@@ -1595,17 +1034,15 @@ pub fn run_template_vxm(
         MaskType::AsParam,
         rvv_op,
         VectorCallbackType::VXM(expected_op),
-        sews,
-        lmuls,
+        befor_op_default,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_vim(
-    expected_op: fn(&mut [u8], &[u8], i64, bool),
+pub fn run_template_v_vim(
+    expected_op: fn(&[u8], i64, &mut [u8], bool),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
     desc: &str,
 ) {
     run_template_ext(
@@ -1615,17 +1052,15 @@ pub fn run_template_vim(
         MaskType::AsParam,
         rvv_op,
         VectorCallbackType::VIM(expected_op),
-        sews,
-        lmuls,
+        befor_op_default,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_mvvm(
-    expected_op: fn(&mut bool, &[u8], &[u8], bool),
+pub fn run_template_m_vvm(
+    expected_op: fn(&[u8], &[u8], &mut bool, bool),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
     desc: &str,
 ) {
     run_template_ext(
@@ -1635,17 +1070,15 @@ pub fn run_template_mvvm(
         MaskType::AsParam,
         rvv_op,
         VectorCallbackType::MVVM(expected_op),
-        sews,
-        lmuls,
+        befor_op_default,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_mvxm(
-    expected_op: fn(&mut bool, &[u8], u64, bool),
+pub fn run_template_m_vxm(
+    expected_op: fn(&[u8], u64, &mut bool, bool),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
     desc: &str,
 ) {
     run_template_ext(
@@ -1655,17 +1088,15 @@ pub fn run_template_mvxm(
         MaskType::AsParam,
         rvv_op,
         VectorCallbackType::MVXM(expected_op),
-        sews,
-        lmuls,
+        befor_op_default,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_mvim(
-    expected_op: fn(&mut bool, &[u8], i64, bool),
+pub fn run_template_m_vim(
+    expected_op: fn(&[u8], i64, &mut bool, bool),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
     desc: &str,
 ) {
     run_template_ext(
@@ -1675,77 +1106,153 @@ pub fn run_template_mvim(
         MaskType::AsParam,
         rvv_op,
         VectorCallbackType::MVIM(expected_op),
-        sews,
-        lmuls,
+        befor_op_default,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_mvv(
-    expected_op: fn(&mut bool, &[u8], &[u8]),
+pub fn run_template_m_vv(
+    expected_op: fn(&[u8], &[u8], &mut bool),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
+    enable_mask: bool,
     desc: &str,
 ) {
     run_template_ext(
         InstructionArgsType::VectorBit,
         InstructionArgsType::Vector,
         InstructionArgsType::Vector,
-        MaskType::Disable,
+        if enable_mask {
+            MaskType::Enable
+        } else {
+            MaskType::Disable
+        },
         rvv_op,
         VectorCallbackType::MVV(expected_op),
-        sews,
-        lmuls,
+        befor_op_default,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_mvx(
-    expected_op: fn(&mut bool, &[u8], u64),
+pub fn run_template_m_vx(
+    expected_op: fn(&[u8], u64, &mut bool),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
+    enable_mask: bool,
     desc: &str,
 ) {
     run_template_ext(
         InstructionArgsType::VectorBit,
         InstructionArgsType::Vector,
         InstructionArgsType::Scalar,
-        MaskType::Disable,
+        if enable_mask {
+            MaskType::Enable
+        } else {
+            MaskType::Disable
+        },
         rvv_op,
         VectorCallbackType::MVX(expected_op),
-        sews,
-        lmuls,
+        befor_op_default,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_mvi(
-    expected_op: fn(&mut bool, &[u8], i64),
+pub fn run_template_m_vi(
+    expected_op: fn(&[u8], i64, &mut bool),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
+    enable_mask: bool,
     desc: &str,
 ) {
     run_template_ext(
         InstructionArgsType::VectorBit,
         InstructionArgsType::Vector,
         InstructionArgsType::Immediate,
-        MaskType::Disable,
+        if enable_mask {
+            MaskType::Enable
+        } else {
+            MaskType::Disable
+        },
         rvv_op,
         VectorCallbackType::MVI(expected_op),
-        sews,
-        lmuls,
+        befor_op_default,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_wv(
-    expected_op: fn(&mut [u8], &[u8], &[u8]),
+pub fn run_template_m_mm(
+    expected_op: fn(bool, bool, &mut bool),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
+    enable_mask: bool,
+    desc: &str,
+) {
+    run_template_ext(
+        InstructionArgsType::VectorBit,
+        InstructionArgsType::VectorBit,
+        InstructionArgsType::VectorBit,
+        if enable_mask {
+            MaskType::Enable
+        } else {
+            MaskType::Disable
+        },
+        rvv_op,
+        VectorCallbackType::MMM(expected_op),
+        befor_op_default,
+        masked_op_default,
+        desc,
+    );
+}
+
+pub fn run_template_w_vv(
+    expected_op: fn(&[u8], &[u8], &mut [u8]),
+    rvv_op: fn(&[u8], &[u8], MaskType),
+    enable_mask: bool,
+    desc: &str,
+) {
+    run_template_ext(
+        InstructionArgsType::Vector2,
+        InstructionArgsType::Vector,
+        InstructionArgsType::Vector,
+        if enable_mask {
+            MaskType::Enable
+        } else {
+            MaskType::Disable
+        },
+        rvv_op,
+        VectorCallbackType::VV(expected_op),
+        befor_op_wide,
+        masked_op_default,
+        desc,
+    );
+}
+
+pub fn run_template_w_vx(
+    expected_op: fn(&[u8], u64, &mut [u8]),
+    rvv_op: fn(&[u8], &[u8], MaskType),
+    enable_mask: bool,
+    desc: &str,
+) {
+    run_template_ext(
+        InstructionArgsType::Vector2,
+        InstructionArgsType::Vector,
+        InstructionArgsType::Scalar,
+        if enable_mask {
+            MaskType::Enable
+        } else {
+            MaskType::Disable
+        },
+        rvv_op,
+        VectorCallbackType::VX(expected_op),
+        befor_op_wide,
+        masked_op_default,
+        desc,
+    );
+}
+
+pub fn run_template_v_wv(
+    expected_op: fn(&[u8], &[u8], &mut [u8]),
+    rvv_op: fn(&[u8], &[u8], MaskType),
     enable_mask: bool,
     desc: &str,
 ) {
@@ -1760,17 +1267,15 @@ pub fn run_template_wv(
         },
         rvv_op,
         VectorCallbackType::VV(expected_op),
-        sews,
-        lmuls,
+        befor_op_wide,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_wx(
-    expected_op: fn(&mut [u8], &[u8], u64),
+pub fn run_template_v_wx(
+    expected_op: fn(&[u8], u64, &mut [u8]),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
     enable_mask: bool,
     desc: &str,
 ) {
@@ -1785,17 +1290,15 @@ pub fn run_template_wx(
         },
         rvv_op,
         VectorCallbackType::VX(expected_op),
-        sews,
-        lmuls,
+        befor_op_wide,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_wi(
-    expected_op: fn(&mut [u8], &[u8], i64),
+pub fn run_template_v_wi(
+    expected_op: fn(&[u8], i64, &mut [u8]),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
     desc: &str,
 ) {
     run_template_ext(
@@ -1805,17 +1308,15 @@ pub fn run_template_wi(
         MaskType::Disable,
         rvv_op,
         VectorCallbackType::VI(expected_op),
-        sews,
-        lmuls,
+        befor_op_wide,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_vv(
-    expected_op: fn(&mut [u8], &[u8], &[u8]),
+pub fn run_template_v_vv(
+    expected_op: fn(&[u8], &[u8], &mut [u8]),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
     enable_mask: bool,
     desc: &str,
 ) {
@@ -1830,17 +1331,15 @@ pub fn run_template_vv(
         },
         rvv_op,
         VectorCallbackType::VV(expected_op),
-        sews,
-        lmuls,
+        befor_op_default,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_vx(
-    expected_op: fn(&mut [u8], &[u8], u64),
+pub fn run_template_v_vx(
+    expected_op: fn(&[u8], u64, &mut [u8]),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
     enable_mask: bool,
     desc: &str,
 ) {
@@ -1855,17 +1354,15 @@ pub fn run_template_vx(
         },
         rvv_op,
         VectorCallbackType::VX(expected_op),
-        sews,
-        lmuls,
+        befor_op_default,
+        masked_op_default,
         desc,
     );
 }
 
-pub fn run_template_vi(
-    expected_op: fn(&mut [u8], &[u8], i64),
+pub fn run_template_v_vi(
+    expected_op: fn(&[u8], i64, &mut [u8]),
     rvv_op: fn(&[u8], &[u8], MaskType),
-    sews: &[u64],
-    lmuls: &[i64],
     single: bool,
     desc: &str,
 ) {
@@ -1880,8 +1377,184 @@ pub fn run_template_vi(
         MaskType::Disable,
         rvv_op,
         VectorCallbackType::VI(expected_op),
-        sews,
-        lmuls,
+        befor_op_default,
+        masked_op_default,
         desc,
     );
+}
+
+pub fn run_template_w_wv(
+    expected_op: fn(&[u8], &[u8], &mut [u8]),
+    rvv_op: fn(&[u8], &[u8], MaskType),
+    enable_mask: bool,
+    desc: &str,
+) {
+    run_template_ext(
+        InstructionArgsType::Vector2,
+        InstructionArgsType::Vector2,
+        InstructionArgsType::Vector,
+        if enable_mask {
+            MaskType::Enable
+        } else {
+            MaskType::Disable
+        },
+        rvv_op,
+        VectorCallbackType::VV(expected_op),
+        befor_op_wide,
+        masked_op_default,
+        desc,
+    );
+}
+
+pub fn run_template_w_wx(
+    expected_op: fn(&[u8], u64, &mut [u8]),
+    rvv_op: fn(&[u8], &[u8], MaskType),
+    enable_mask: bool,
+    desc: &str,
+) {
+    run_template_ext(
+        InstructionArgsType::Vector2,
+        InstructionArgsType::Vector2,
+        InstructionArgsType::Scalar,
+        if enable_mask {
+            MaskType::Enable
+        } else {
+            MaskType::Disable
+        },
+        rvv_op,
+        VectorCallbackType::VX(expected_op),
+        befor_op_wide,
+        masked_op_default,
+        desc,
+    );
+}
+
+pub fn run_template_r_vv(
+    expected_op: fn(&[u8], &[u8], &mut [u8], usize),
+    rvv_op: fn(&[u8], &[u8], MaskType),
+    enable_mask: bool,
+    desc: &str,
+) {
+    run_template_ext(
+        InstructionArgsType::VectorRed,
+        InstructionArgsType::Vector,
+        InstructionArgsType::Vector,
+        if enable_mask {
+            MaskType::Enable
+        } else {
+            MaskType::Disable
+        },
+        rvv_op,
+        VectorCallbackType::VVR(expected_op),
+        befor_op_default,
+        masked_op_red,
+        desc,
+    );
+}
+
+pub fn run_template_wr_vw(
+    expected_op: fn(&[u8], &[u8], &mut [u8], usize),
+    rvv_op: fn(&[u8], &[u8], MaskType),
+    enable_mask: bool,
+    desc: &str,
+) {
+    run_template_ext(
+        InstructionArgsType::VectorRed2,
+        InstructionArgsType::Vector,
+        InstructionArgsType::Vector2,
+        if enable_mask {
+            MaskType::Enable
+        } else {
+            MaskType::Disable
+        },
+        rvv_op,
+        VectorCallbackType::VVR(expected_op),
+        befor_op_wide,
+        masked_op_red,
+        desc,
+    );
+}
+
+pub fn run_template_v_n(
+    expected_op: fn(&[u8], &[u8], &mut [u8]),
+    rvv_op: fn(&[u8], &[u8], MaskType),
+    narrow: u64,
+    enable_mask: bool,
+    desc: &str,
+) {
+    fn before_op_2(_: f64, lmul: f64, _: u64) -> bool {
+        let v = 0.5;
+        let emul = lmul * v;
+        if emul >= 0.125 && emul <= 8.0 {
+            true
+        } else {
+            false
+        }
+    }
+    fn before_op_4(_: f64, lmul: f64, _: u64) -> bool {
+        let v = 0.25;
+        let emul = lmul * v;
+        if emul >= 0.125 && emul <= 8.0 {
+            true
+        } else {
+            false
+        }
+    }
+    fn before_op_8(_: f64, lmul: f64, _: u64) -> bool {
+        let v = 0.125;
+        let emul = lmul * v;
+        if emul >= 0.125 && emul <= 8.0 {
+            true
+        } else {
+            false
+        }
+    }
+    match narrow {
+        2 => run_template_ext(
+            InstructionArgsType::Vector,
+            InstructionArgsType::VectorNarrow2,
+            InstructionArgsType::Vector,
+            if enable_mask {
+                MaskType::Enable
+            } else {
+                MaskType::Disable
+            },
+            rvv_op,
+            VectorCallbackType::VV(expected_op),
+            before_op_2,
+            masked_op_default,
+            desc,
+        ),
+        4 => run_template_ext(
+            InstructionArgsType::Vector,
+            InstructionArgsType::VectorNarrow4,
+            InstructionArgsType::Vector,
+            if enable_mask {
+                MaskType::Enable
+            } else {
+                MaskType::Disable
+            },
+            rvv_op,
+            VectorCallbackType::VV(expected_op),
+            before_op_4,
+            masked_op_default,
+            desc,
+        ),
+        8 => run_template_ext(
+            InstructionArgsType::Vector,
+            InstructionArgsType::VectorNarrow8,
+            InstructionArgsType::Vector,
+            if enable_mask {
+                MaskType::Enable
+            } else {
+                MaskType::Disable
+            },
+            rvv_op,
+            VectorCallbackType::VV(expected_op),
+            before_op_8,
+            masked_op_default,
+            desc,
+        ),
+        _ => panic!("Abort"),
+    };
 }

--- a/cases/src/runner.rs
+++ b/cases/src/runner.rs
@@ -589,6 +589,7 @@ fn run_rvv_op(rvv_data: &mut RVVTestData, op: fn(&[u8], &[u8], MaskType)) {
             buf.resize(VLEN / 8, 0);
             let mask = rvv_data.get_rvv_mask();
             buf[..mask.len()].copy_from_slice(&mask);
+
             vl1r_v0(&buf);
         }
 
@@ -1256,7 +1257,7 @@ pub fn run_template_v_wi(
         InstructionArgsType::Vector,
         InstructionArgsType::Vector2,
         InstructionArgsType::UImmediate,
-        MaskType::Disable,
+        MaskType::Enable,
         rvv_op,
         VectorCallbackType::VI(expected_op),
         befor_op_wide,
@@ -1314,6 +1315,7 @@ pub fn run_template_v_vx(
 pub fn run_template_v_vi(
     expected_op: fn(&[u8], i64, &mut [u8]),
     rvv_op: fn(&[u8], &[u8], MaskType),
+    enable_mask: bool,
     single: bool,
     desc: &str,
 ) {
@@ -1325,7 +1327,11 @@ pub fn run_template_v_vi(
         } else {
             InstructionArgsType::UImmediate
         },
-        MaskType::Disable,
+        if enable_mask {
+            MaskType::Enable
+        } else {
+            MaskType::Disable
+        },
         rvv_op,
         VectorCallbackType::VI(expected_op),
         befor_op_default,

--- a/cases/src/single_saturating_add_subtract_cases.rs
+++ b/cases/src/single_saturating_add_subtract_cases.rs
@@ -184,117 +184,315 @@ fn expected_op_saddu_vi(lhs: &[u8], imm: i64, result: &mut [u8]) {
     }
 }
 fn test_vsaddu_vi() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                16 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 16");
-                }
-                15 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 15");
-                }
-                14 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 14");
-                }
-                13 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 13");
-                }
-                12 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 12");
-                }
-                11 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 11");
-                }
-                10 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 10");
-                }
-                9 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 9");
-                }
-                8 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 8");
-                }
-                7 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 7");
-                }
-                6 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 6");
-                }
-                5 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 5");
-                }
-                4 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 4");
-                }
-                3 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 3");
-                }
-                2 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 2");
-                }
-                1 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 1");
-                }
-                0 => {
-                    rvv_asm!("vsaddu.vi v24, v8, 0");
-                }
-                -1 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -1");
-                }
-                -2 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -2");
-                }
-                -3 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -3");
-                }
-                -4 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -4");
-                }
-                -5 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -5");
-                }
-                -6 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -6");
-                }
-                -7 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -7");
-                }
-                -8 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -8");
-                }
-                -9 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -9");
-                }
-                -10 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -10");
-                }
-                -11 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -11");
-                }
-                -12 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -12");
-                }
-                -13 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -13");
-                }
-                -14 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -14");
-                }
-                -15 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -15");
-                }
-                -16 => {
-                    rvv_asm!("vsaddu.vi v24, v8, -16");
-                }
+                -16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, -1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsaddu.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("can't support this immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
 
-    run_template_v_vi(expected_op_saddu_vi, op, true, "vsaddu.vi");
+    run_template_v_vi(expected_op_saddu_vi, op, true, true, "vsaddu.vi");
 }
 
 fn expected_op_sadd(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -471,113 +669,315 @@ fn expected_op_sadd_vi(lhs: &[u8], imm: i64, result: &mut [u8]) {
     expected_op_sadd(lhs, imm as u64, result);
 }
 fn test_vsadd_vi() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                15 => {
-                    rvv_asm!("vsadd.vi v24, v8, 15");
-                }
-                14 => {
-                    rvv_asm!("vsadd.vi v24, v8, 14");
-                }
-                13 => {
-                    rvv_asm!("vsadd.vi v24, v8, 13");
-                }
-                12 => {
-                    rvv_asm!("vsadd.vi v24, v8, 12");
-                }
-                11 => {
-                    rvv_asm!("vsadd.vi v24, v8, 11");
-                }
-                10 => {
-                    rvv_asm!("vsadd.vi v24, v8, 10");
-                }
-                9 => {
-                    rvv_asm!("vsadd.vi v24, v8, 9");
-                }
-                8 => {
-                    rvv_asm!("vsadd.vi v24, v8, 8");
-                }
-                7 => {
-                    rvv_asm!("vsadd.vi v24, v8, 7");
-                }
-                6 => {
-                    rvv_asm!("vsadd.vi v24, v8, 6");
-                }
-                5 => {
-                    rvv_asm!("vsadd.vi v24, v8, 5");
-                }
-                4 => {
-                    rvv_asm!("vsadd.vi v24, v8, 4");
-                }
-                3 => {
-                    rvv_asm!("vsadd.vi v24, v8, 3");
-                }
-                2 => {
-                    rvv_asm!("vsadd.vi v24, v8, 2");
-                }
-                1 => {
-                    rvv_asm!("vsadd.vi v24, v8, 1");
-                }
-                0 => {
-                    rvv_asm!("vsadd.vi v24, v8, 0");
-                }
-                -1 => {
-                    rvv_asm!("vsadd.vi v24, v8, -1");
-                }
-                -2 => {
-                    rvv_asm!("vsadd.vi v24, v8, -2");
-                }
-                -3 => {
-                    rvv_asm!("vsadd.vi v24, v8, -3");
-                }
-                -4 => {
-                    rvv_asm!("vsadd.vi v24, v8, -4");
-                }
-                -5 => {
-                    rvv_asm!("vsadd.vi v24, v8, -5");
-                }
-                -6 => {
-                    rvv_asm!("vsadd.vi v24, v8, -6");
-                }
-                -7 => {
-                    rvv_asm!("vsadd.vi v24, v8, -7");
-                }
-                -8 => {
-                    rvv_asm!("vsadd.vi v24, v8, -8");
-                }
-                -9 => {
-                    rvv_asm!("vsadd.vi v24, v8, -9");
-                }
-                -10 => {
-                    rvv_asm!("vsadd.vi v24, v8, -10");
-                }
-                -11 => {
-                    rvv_asm!("vsadd.vi v24, v8, -11");
-                }
-                -12 => {
-                    rvv_asm!("vsadd.vi v24, v8, -12");
-                }
-                -13 => {
-                    rvv_asm!("vsadd.vi v24, v8, -13");
-                }
-                -14 => {
-                    rvv_asm!("vsadd.vi v24, v8, -14");
-                }
-                -15 => {
-                    rvv_asm!("vsadd.vi v24, v8, -15");
-                }
-                -16 => {
-                    rvv_asm!("vsadd.vi v24, v8, -16");
-                }
+                -16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, -1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, -1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsadd.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsadd.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("can't support this immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
-    run_template_v_vi(expected_op_sadd_vi, op, true, "vsadd.vi");
+
+    run_template_v_vi(expected_op_sadd_vi, op, true, true, "vsadd.vi");
 }
 
 fn expected_op_ssubu(lhs: &[u8], x: u64, result: &mut [u8]) {

--- a/cases/src/single_width_averaging_cases.rs
+++ b/cases/src/single_width_averaging_cases.rs
@@ -1,7 +1,7 @@
-use core::arch::asm;
+use core::{arch::asm, convert::TryInto};
 use rvv_asm::rvv_asm;
 use rvv_testcases::misc::{to_i64, to_u64, Widening, U256, U512};
-use rvv_testcases::runner::{run_template_v_vv, MaskType};
+use rvv_testcases::runner::{run_template_v_vv, run_template_v_vx, MaskType};
 
 fn test_vaaddu_vv() {
     fn expected_op(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -46,6 +46,49 @@ fn test_vaaddu_vv() {
     run_template_v_vv(expected_op, op, true, "vaaddu.vv");
 }
 
+fn test_vaaddu_vx() {
+    fn expected_op(lhs: &[u8], x: u64, result: &mut [u8]) {
+        assert!(lhs.len() == result.len());
+        match lhs.len() {
+            8 => {
+                let l = to_u64(lhs);
+
+                let (r, _) = (l as u128).overflowing_add(x as u128);
+                let r2 = (r >> 1) as u64;
+                result.copy_from_slice(&r2.to_le_bytes());
+            }
+            32 => {
+                let l = U256::from_little_endian(lhs);
+                let r = U256::from(x);
+
+                // widening
+                let (r, _) = U512::from(l).overflowing_add(U512::from(r));
+                // narrow again
+                let r2: U256 = (r >> 1).into();
+                r2.to_little_endian(result);
+            }
+            _ => {
+                panic!("expected_op_aaddu");
+            }
+        }
+    }
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vaaddu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vaaddu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
+    }
+    run_template_v_vx(expected_op, op, true, "vaaddu.vx");
+}
+
 fn test_vaadd_vv() {
     fn expected_op(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
@@ -86,6 +129,48 @@ fn test_vaadd_vv() {
         }
     }
     run_template_v_vv(expected_op, op, true, "vaadd.vv");
+}
+
+fn test_vaadd_vx() {
+    fn expected_op(lhs: &[u8], x: u64, result: &mut [u8]) {
+        assert!(lhs.len() == result.len());
+        match lhs.len() {
+            8 => {
+                let l = to_i64(lhs);
+
+                let (r, _) = (l as i128).overflowing_add((x as i64) as i128);
+                let r2 = (r >> 1) as i64;
+                result.copy_from_slice(&r2.to_le_bytes());
+            }
+            32 => {
+                let l = U256::from_little_endian(lhs);
+
+                let r = x.sign_extend();
+                let (r, _) = l.sign_extend().overflowing_add(r.sign_extend());
+                let r2 = r >> 1;
+                let r3: U256 = r2.into();
+                r3.to_little_endian(result)
+            }
+            _ => {
+                panic!("expected_op_aadd");
+            }
+        }
+    }
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vaadd.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vaadd.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
+    }
+    run_template_v_vx(expected_op, op, true, "vaadd.vx");
 }
 
 fn test_vasubu_vv() {
@@ -131,6 +216,49 @@ fn test_vasubu_vv() {
     run_template_v_vv(expected_op, op, true, "vasubu.vv");
 }
 
+fn test_vasubu_vx() {
+    fn expected_op(lhs: &[u8], x: u64, result: &mut [u8]) {
+        assert!(lhs.len() == result.len());
+        match lhs.len() {
+            8 => {
+                let l = to_u64(lhs);
+
+                let (r, _) = (l as u128).overflowing_sub(x as u128);
+                let r2 = (r >> 1) as u64;
+                result.copy_from_slice(&r2.to_le_bytes());
+            }
+            32 => {
+                let l = U256::from_little_endian(lhs);
+                let r = U256::from(x);
+
+                // widening
+                let (r, _) = U512::from(l).overflowing_sub(U512::from(r));
+                // narrow again
+                let r2: U256 = (r >> 1).into();
+                r2.to_little_endian(result);
+            }
+            _ => {
+                panic!("expected_op_aaddu");
+            }
+        }
+    }
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vasubu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vasubu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
+    }
+    run_template_v_vx(expected_op, op, true, "vasubu.vx");
+}
+
 fn test_vasub_vv() {
     fn expected_op(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
@@ -174,9 +302,55 @@ fn test_vasub_vv() {
     run_template_v_vv(expected_op, op, true, "vasub.vv");
 }
 
+fn test_vasub_vx() {
+    fn expected_op(lhs: &[u8], x: u64, result: &mut [u8]) {
+        assert!(lhs.len() == result.len());
+        match lhs.len() {
+            8 => {
+                let l = to_i64(lhs);
+
+                let (r, _) = (l as i128).overflowing_sub((x as i64) as i128);
+                let r2 = (r >> 1) as i64;
+                result.copy_from_slice(&r2.to_le_bytes());
+            }
+            32 => {
+                let l = U256::from_little_endian(lhs);
+
+                let r = x.sign_extend();
+                let (r, _) = l.sign_extend().overflowing_sub(r.sign_extend());
+                let r2 = r >> 1;
+                let r3: U256 = r2.into();
+                r3.to_little_endian(result)
+            }
+            _ => {
+                panic!("expected_op_aadd");
+            }
+        }
+    }
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vasub.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vasub.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
+    }
+    run_template_v_vx(expected_op, op, true, "vasub.vx");
+}
+
 pub fn test_single_width_averaging_add_and_subtract() {
     test_vaaddu_vv();
+    test_vaaddu_vx();
     test_vaadd_vv();
+    test_vaadd_vx();
     test_vasubu_vv();
+    test_vasubu_vx();
     test_vasub_vv();
+    test_vasub_vx();
 }

--- a/cases/src/single_width_averaging_cases.rs
+++ b/cases/src/single_width_averaging_cases.rs
@@ -1,24 +1,24 @@
-use alloc::boxed::Box;
 use core::arch::asm;
 use rvv_asm::rvv_asm;
-use rvv_testcases::intrinsic::vop_vv;
+use rvv_testcases::misc::{to_i64, to_u64, Widening, U256, U512};
+use rvv_testcases::runner::{run_template_v_vv, MaskType};
 
-use rvv_testcases::misc::{Widening, U256, U512};
-use rvv_testcases::runner::{run_vop_vv, ExpectedOp, WideningCategory};
-
-pub fn test_single_width_averaging_add_and_subtract() {
-    // vaaddu.vv
-    fn vaaddu_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vaaddu.vv v24, v8, v16");
-        });
-    }
-    pub fn expected_vaaddu_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
+fn test_vaaddu_vv() {
+    fn expected_op(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
-        let l = U256::from_little_endian(lhs);
-        let r = U256::from_little_endian(rhs);
         match lhs.len() {
+            8 => {
+                let l = to_u64(lhs);
+                let r = to_u64(rhs);
+
+                let (r, _) = (l as u128).overflowing_add(r as u128);
+                let r2 = (r >> 1) as u64;
+                result.copy_from_slice(&r2.to_le_bytes());
+            }
             32 => {
+                let l = U256::from_little_endian(lhs);
+                let r = U256::from_little_endian(rhs);
+
                 // widening
                 let (r, _) = U512::from(l).overflowing_add(U512::from(r));
                 // narrow again
@@ -30,28 +30,38 @@ pub fn test_single_width_averaging_add_and_subtract() {
             }
         }
     }
-    run_vop_vv(
-        256,
-        1,
-        100,
-        ExpectedOp::Normal(Box::new(expected_vaaddu_vv)),
-        vaaddu_vv,
-        WideningCategory::None,
-        "vaaddu.vv",
-    );
-
-    // vaadd.vv
-    fn vaadd_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vaadd.vv v24, v8, v16");
-        });
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vaaddu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vaaddu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    pub fn expected_vaadd_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
+    run_template_v_vv(expected_op, op, true, "vaaddu.vv");
+}
+
+fn test_vaadd_vv() {
+    fn expected_op(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
-        let l = U256::from_little_endian(lhs);
-        let r = U256::from_little_endian(rhs);
         match lhs.len() {
+            8 => {
+                let l = to_i64(lhs);
+                let r = to_i64(rhs);
+
+                let (r, _) = (l as i128).overflowing_add(r as i128);
+                let r2 = (r >> 1) as i64;
+                result.copy_from_slice(&r2.to_le_bytes());
+            }
             32 => {
+                let l = U256::from_little_endian(lhs);
+                let r = U256::from_little_endian(rhs);
+
                 let (r, _) = l.sign_extend().overflowing_add(r.sign_extend());
                 let r2 = r >> 1;
                 let r3: U256 = r2.into();
@@ -62,28 +72,38 @@ pub fn test_single_width_averaging_add_and_subtract() {
             }
         }
     }
-    run_vop_vv(
-        256,
-        1,
-        100,
-        ExpectedOp::Normal(Box::new(expected_vaadd_vv)),
-        vaadd_vv,
-        WideningCategory::None,
-        "vaadd.vv",
-    );
-
-    // vasubu.vv
-    fn vasubu_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vasubu.vv v24, v8, v16");
-        });
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vaadd.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vaadd.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    pub fn expected_vasubu_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
+    run_template_v_vv(expected_op, op, true, "vaadd.vv");
+}
+
+fn test_vasubu_vv() {
+    fn expected_op(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
-        let l = U256::from_little_endian(lhs);
-        let r = U256::from_little_endian(rhs);
         match lhs.len() {
+            8 => {
+                let l = to_u64(lhs) as u128;
+                let r = to_u64(rhs) as u128;
+
+                let r = l.wrapping_sub(r);
+                let r2 = (r >> 1) as u64;
+                result.copy_from_slice(&r2.to_le_bytes());
+            }
             32 => {
+                let l = U256::from_little_endian(lhs);
+                let r = U256::from_little_endian(rhs);
+
                 let l: U512 = l.into();
                 let r: U512 = r.into();
                 let r = l.wrapping_sub(r);
@@ -91,32 +111,42 @@ pub fn test_single_width_averaging_add_and_subtract() {
                 r2.to_little_endian(result);
             }
             _ => {
-                panic!("expected_op_asubu");
+                panic!("expected_op_aadd");
             }
         }
     }
-    run_vop_vv(
-        256,
-        1,
-        100,
-        ExpectedOp::Normal(Box::new(expected_vasubu_vv)),
-        vasubu_vv,
-        WideningCategory::None,
-        "vasubu.vv",
-    );
-
-    // vasub.vv
-    fn vasub_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vasub.vv v24, v8, v16");
-        });
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vasubu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vasubu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    pub fn expected_vasub_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
+    run_template_v_vv(expected_op, op, true, "vasubu.vv");
+}
+
+fn test_vasub_vv() {
+    fn expected_op(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
-        let l = U256::from_little_endian(lhs);
-        let r = U256::from_little_endian(rhs);
         match lhs.len() {
+            8 => {
+                let l = to_i64(lhs) as i128;
+                let r = to_i64(rhs) as i128;
+
+                let r = l.wrapping_sub(r);
+                let r2 = (r >> 1) as i64;
+                result.copy_from_slice(&r2.to_le_bytes());
+            }
             32 => {
+                let l = U256::from_little_endian(lhs);
+                let r = U256::from_little_endian(rhs);
+
                 let l: U512 = l.sign_extend();
                 let r: U512 = r.sign_extend();
                 let (r, _) = l.overflowing_sub(r);
@@ -124,17 +154,29 @@ pub fn test_single_width_averaging_add_and_subtract() {
                 r2.to_little_endian(result)
             }
             _ => {
-                panic!("expected_op_asub");
+                panic!("expected_op_aadd");
             }
         }
     }
-    run_vop_vv(
-        256,
-        1,
-        100,
-        ExpectedOp::Normal(Box::new(expected_vasub_vv)),
-        vasub_vv,
-        WideningCategory::None,
-        "vasub.vv",
-    );
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vasub.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vasub.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
+    }
+    run_template_v_vv(expected_op, op, true, "vasub.vv");
+}
+
+pub fn test_single_width_averaging_add_and_subtract() {
+    test_vaaddu_vv();
+    test_vaadd_vv();
+    test_vasubu_vv();
+    test_vasub_vv();
 }

--- a/cases/src/single_width_scaling_shift.rs
+++ b/cases/src/single_width_scaling_shift.rs
@@ -1,12 +1,7 @@
-use alloc::boxed::Box;
 use core::{arch::asm, convert::TryInto};
 use eint::{Eint, E256};
 use rvv_asm::rvv_asm;
-use rvv_testcases::{
-    intrinsic::{vop_vi, vop_vv, vop_vx},
-    misc::avl_iterator,
-    runner::{run_vop_vi, run_vop_vv, run_vop_vx, ExpectedOp, WideningCategory},
-};
+use rvv_testcases::runner::{run_template_v_vi, run_template_v_vv, run_template_v_vx, MaskType};
 
 fn expected_op_vssrl_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
     assert_eq!(lhs.len(), result.len());
@@ -41,23 +36,22 @@ fn expected_op_vssrl_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-fn test_vssrl_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vssrl.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vssrl_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vssrl.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vssrl.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_vssrl_vx,
-        op,
-        WideningCategory::None,
-        "vssrl.vx",
-    );
+    run_template_v_vx(expected_op_vssrl_vx, op, true, "vssrl.vx");
 }
 
 fn expected_op_ssrl_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -98,29 +92,30 @@ fn expected_op_ssrl_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vssrl_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vssrl.vv v24, v8, v16");
-        });
+fn test_vssrl_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vssrl.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vssrl.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_ssrl_vv)),
-        op,
-        WideningCategory::None,
-        "vssrl.vv",
-    );
+    run_template_v_vv(expected_op_ssrl_vv, op, true, "vssrl.vv");
 }
 
 fn expected_op_vssrl_vi(lhs: &[u8], imm: i64, result: &mut [u8]) {
     expected_op_vssrl_vx(lhs, imm as u64, result);
 }
-fn test_vssrl_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
-    fn op(lhs: &[u8], imm: i64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vi(lhs, imm, result, sew, avl, lmul, |imm| unsafe {
+fn test_vssrl_vi() {
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
             match imm {
                 31 => {
                     rvv_asm!("vssrl.vi v24, v8, 31");
@@ -222,18 +217,9 @@ fn test_vssrl_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
                     panic!("can't support this immediate: {}", imm);
                 }
             }
-        });
+        }
     }
-    run_vop_vi(
-        sew,
-        lmul,
-        avl,
-        imm,
-        expected_op_vssrl_vi,
-        op,
-        WideningCategory::None,
-        "vssrl.vi",
-    );
+    run_template_v_vi(expected_op_vssrl_vi, op, false, "vssrl.vi");
 }
 
 fn expected_op_vssra_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -269,23 +255,22 @@ fn expected_op_vssra_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-fn test_vssra_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vssra.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vssra_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vssra.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vssra.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_vssra_vx,
-        op,
-        WideningCategory::None,
-        "vssra.vx",
-    );
+    run_template_v_vx(expected_op_vssra_vx, op, true, "vssra.vx");
 }
 
 fn expected_op_ssra_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -326,29 +311,30 @@ fn expected_op_ssra_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vssra_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vssra.vv v24, v8, v16");
-        });
+fn test_vssra_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vssra.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vssra.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_ssra_vv)),
-        op,
-        WideningCategory::None,
-        "vssra.vv",
-    );
+    run_template_v_vv(expected_op_ssra_vv, op, true, "vssra.vv");
 }
 
 fn expected_op_vssra_vi(lhs: &[u8], imm: i64, result: &mut [u8]) {
     expected_op_vssra_vx(lhs, imm as u64, result);
 }
-fn test_vssra_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
-    fn op(lhs: &[u8], imm: i64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vi(lhs, imm, result, sew, avl, lmul, |imm| unsafe {
+fn test_vssra_vi() {
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
             match imm {
                 31 => {
                     rvv_asm!("vssra.vi v24, v8, 31");
@@ -450,38 +436,17 @@ fn test_vssra_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
                     panic!("can't support this immediate: {}", imm);
                 }
             }
-        });
+        }
     }
-    run_vop_vi(
-        sew,
-        lmul,
-        avl,
-        imm,
-        expected_op_vssra_vi,
-        op,
-        WideningCategory::None,
-        "vssra.vi",
-    );
+    run_template_v_vi(expected_op_vssra_vi, op, false, "vssra.vi");
 }
 
 pub fn test_single_with_scaling_shift() {
-    let mut imm = 0;
-    for sew in [8, 16, 32, 64, 128, 256] {
-        for lmul in [-2, 1, 4, 8] {
-            for avl in avl_iterator(sew, 4) {
-                test_vssrl_vx(sew, lmul, avl);
-                test_vssrl_vv(sew, lmul, avl);
-                test_vssrl_vi(sew, lmul, avl, imm);
+    test_vssrl_vx();
+    test_vssrl_vv();
+    test_vssrl_vi();
 
-                test_vssra_vx(sew, lmul, avl);
-                test_vssra_vv(sew, lmul, avl);
-                test_vssra_vi(sew, lmul, avl, imm);
-
-                imm += 1;
-                if imm > 31 {
-                    imm = 0;
-                }
-            }
-        }
-    }
+    test_vssra_vx();
+    test_vssra_vv();
+    test_vssra_vi();
 }

--- a/cases/src/single_width_scaling_shift.rs
+++ b/cases/src/single_width_scaling_shift.rs
@@ -113,113 +113,306 @@ fn expected_op_vssrl_vi(lhs: &[u8], imm: i64, result: &mut [u8]) {
     expected_op_vssrl_vx(lhs, imm as u64, result);
 }
 fn test_vssrl_vi() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                31 => {
-                    rvv_asm!("vssrl.vi v24, v8, 31");
-                }
-                30 => {
-                    rvv_asm!("vssrl.vi v24, v8, 30");
-                }
-                29 => {
-                    rvv_asm!("vssrl.vi v24, v8, 29");
-                }
-                28 => {
-                    rvv_asm!("vssrl.vi v24, v8, 28");
-                }
-                27 => {
-                    rvv_asm!("vssrl.vi v24, v8, 27");
-                }
-                26 => {
-                    rvv_asm!("vssrl.vi v24, v8, 26");
-                }
-                25 => {
-                    rvv_asm!("vssrl.vi v24, v8, 25");
-                }
-                24 => {
-                    rvv_asm!("vssrl.vi v24, v8, 24");
-                }
-                23 => {
-                    rvv_asm!("vssrl.vi v24, v8, 23");
-                }
-                22 => {
-                    rvv_asm!("vssrl.vi v24, v8, 22");
-                }
-                21 => {
-                    rvv_asm!("vssrl.vi v24, v8, 21");
-                }
-                20 => {
-                    rvv_asm!("vssrl.vi v24, v8, 20");
-                }
-                19 => {
-                    rvv_asm!("vssrl.vi v24, v8, 19");
-                }
-                18 => {
-                    rvv_asm!("vssrl.vi v24, v8, 18");
-                }
-                17 => {
-                    rvv_asm!("vssrl.vi v24, v8, 17");
-                }
-                16 => {
-                    rvv_asm!("vssrl.vi v24, v8, 16");
-                }
-                15 => {
-                    rvv_asm!("vssrl.vi v24, v8, 15");
-                }
-                14 => {
-                    rvv_asm!("vssrl.vi v24, v8, 14");
-                }
-                13 => {
-                    rvv_asm!("vssrl.vi v24, v8, 13");
-                }
-                12 => {
-                    rvv_asm!("vssrl.vi v24, v8, 12");
-                }
-                11 => {
-                    rvv_asm!("vssrl.vi v24, v8, 11");
-                }
-                10 => {
-                    rvv_asm!("vssrl.vi v24, v8, 10");
-                }
-                9 => {
-                    rvv_asm!("vssrl.vi v24, v8, 9");
-                }
-                8 => {
-                    rvv_asm!("vssrl.vi v24, v8, 8");
-                }
-                7 => {
-                    rvv_asm!("vssrl.vi v24, v8, 7");
-                }
-                6 => {
-                    rvv_asm!("vssrl.vi v24, v8, 6");
-                }
-                5 => {
-                    rvv_asm!("vssrl.vi v24, v8, 5");
-                }
-                4 => {
-                    rvv_asm!("vssrl.vi v24, v8, 4");
-                }
-                3 => {
-                    rvv_asm!("vssrl.vi v24, v8, 3");
-                }
-                2 => {
-                    rvv_asm!("vssrl.vi v24, v8, 2");
-                }
-                1 => {
-                    rvv_asm!("vssrl.vi v24, v8, 1");
-                }
-                0 => {
-                    rvv_asm!("vssrl.vi v24, v8, 0");
-                }
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                17 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 17, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 17");
+                    }
+                    _ => panic!("Abort"),
+                },
+                18 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 18, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 18");
+                    }
+                    _ => panic!("Abort"),
+                },
+                19 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 19, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 19");
+                    }
+                    _ => panic!("Abort"),
+                },
+                20 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 20, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 20");
+                    }
+                    _ => panic!("Abort"),
+                },
+                21 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 21, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 21");
+                    }
+                    _ => panic!("Abort"),
+                },
+                22 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 22, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 22");
+                    }
+                    _ => panic!("Abort"),
+                },
+                23 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 23, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 23");
+                    }
+                    _ => panic!("Abort"),
+                },
+                24 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 24, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 24");
+                    }
+                    _ => panic!("Abort"),
+                },
+                25 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 25, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 25");
+                    }
+                    _ => panic!("Abort"),
+                },
+                26 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 26, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 26");
+                    }
+                    _ => panic!("Abort"),
+                },
+                27 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 27, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 27");
+                    }
+                    _ => panic!("Abort"),
+                },
+                28 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 28, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 28");
+                    }
+                    _ => panic!("Abort"),
+                },
+                29 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 29, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 29");
+                    }
+                    _ => panic!("Abort"),
+                },
+                30 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 30, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 30");
+                    }
+                    _ => panic!("Abort"),
+                },
+                31 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssrl.vi v24, v8, 31, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssrl.vi v24, v8, 31");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("can't support this immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
-    run_template_v_vi(expected_op_vssrl_vi, op, false, "vssrl.vi");
+
+    run_template_v_vi(expected_op_vssrl_vi, op, true, false, "vssrl.vi");
 }
 
 fn expected_op_vssra_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -332,113 +525,306 @@ fn expected_op_vssra_vi(lhs: &[u8], imm: i64, result: &mut [u8]) {
     expected_op_vssra_vx(lhs, imm as u64, result);
 }
 fn test_vssra_vi() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                31 => {
-                    rvv_asm!("vssra.vi v24, v8, 31");
-                }
-                30 => {
-                    rvv_asm!("vssra.vi v24, v8, 30");
-                }
-                29 => {
-                    rvv_asm!("vssra.vi v24, v8, 29");
-                }
-                28 => {
-                    rvv_asm!("vssra.vi v24, v8, 28");
-                }
-                27 => {
-                    rvv_asm!("vssra.vi v24, v8, 27");
-                }
-                26 => {
-                    rvv_asm!("vssra.vi v24, v8, 26");
-                }
-                25 => {
-                    rvv_asm!("vssra.vi v24, v8, 25");
-                }
-                24 => {
-                    rvv_asm!("vssra.vi v24, v8, 24");
-                }
-                23 => {
-                    rvv_asm!("vssra.vi v24, v8, 23");
-                }
-                22 => {
-                    rvv_asm!("vssra.vi v24, v8, 22");
-                }
-                21 => {
-                    rvv_asm!("vssra.vi v24, v8, 21");
-                }
-                20 => {
-                    rvv_asm!("vssra.vi v24, v8, 20");
-                }
-                19 => {
-                    rvv_asm!("vssra.vi v24, v8, 19");
-                }
-                18 => {
-                    rvv_asm!("vssra.vi v24, v8, 18");
-                }
-                17 => {
-                    rvv_asm!("vssra.vi v24, v8, 17");
-                }
-                16 => {
-                    rvv_asm!("vssra.vi v24, v8, 16");
-                }
-                15 => {
-                    rvv_asm!("vssra.vi v24, v8, 15");
-                }
-                14 => {
-                    rvv_asm!("vssra.vi v24, v8, 14");
-                }
-                13 => {
-                    rvv_asm!("vssra.vi v24, v8, 13");
-                }
-                12 => {
-                    rvv_asm!("vssra.vi v24, v8, 12");
-                }
-                11 => {
-                    rvv_asm!("vssra.vi v24, v8, 11");
-                }
-                10 => {
-                    rvv_asm!("vssra.vi v24, v8, 10");
-                }
-                9 => {
-                    rvv_asm!("vssra.vi v24, v8, 9");
-                }
-                8 => {
-                    rvv_asm!("vssra.vi v24, v8, 8");
-                }
-                7 => {
-                    rvv_asm!("vssra.vi v24, v8, 7");
-                }
-                6 => {
-                    rvv_asm!("vssra.vi v24, v8, 6");
-                }
-                5 => {
-                    rvv_asm!("vssra.vi v24, v8, 5");
-                }
-                4 => {
-                    rvv_asm!("vssra.vi v24, v8, 4");
-                }
-                3 => {
-                    rvv_asm!("vssra.vi v24, v8, 3");
-                }
-                2 => {
-                    rvv_asm!("vssra.vi v24, v8, 2");
-                }
-                1 => {
-                    rvv_asm!("vssra.vi v24, v8, 1");
-                }
-                0 => {
-                    rvv_asm!("vssra.vi v24, v8, 0");
-                }
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                17 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 17, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 17");
+                    }
+                    _ => panic!("Abort"),
+                },
+                18 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 18, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 18");
+                    }
+                    _ => panic!("Abort"),
+                },
+                19 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 19, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 19");
+                    }
+                    _ => panic!("Abort"),
+                },
+                20 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 20, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 20");
+                    }
+                    _ => panic!("Abort"),
+                },
+                21 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 21, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 21");
+                    }
+                    _ => panic!("Abort"),
+                },
+                22 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 22, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 22");
+                    }
+                    _ => panic!("Abort"),
+                },
+                23 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 23, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 23");
+                    }
+                    _ => panic!("Abort"),
+                },
+                24 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 24, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 24");
+                    }
+                    _ => panic!("Abort"),
+                },
+                25 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 25, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 25");
+                    }
+                    _ => panic!("Abort"),
+                },
+                26 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 26, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 26");
+                    }
+                    _ => panic!("Abort"),
+                },
+                27 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 27, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 27");
+                    }
+                    _ => panic!("Abort"),
+                },
+                28 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 28, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 28");
+                    }
+                    _ => panic!("Abort"),
+                },
+                29 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 29, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 29");
+                    }
+                    _ => panic!("Abort"),
+                },
+                30 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 30, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 30");
+                    }
+                    _ => panic!("Abort"),
+                },
+                31 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vssra.vi v24, v8, 31, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vssra.vi v24, v8, 31");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("can't support this immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
-    run_template_v_vi(expected_op_vssra_vi, op, false, "vssra.vi");
+
+    run_template_v_vi(expected_op_vssra_vi, op, true, false, "vssra.vi");
 }
 
 pub fn test_single_with_scaling_shift() {

--- a/cases/src/single_width_shift_cases.rs
+++ b/cases/src/single_width_shift_cases.rs
@@ -1,107 +1,11 @@
-use core::arch::asm;
+use core::{arch::asm, convert::TryInto};
 
-use alloc::boxed::Box;
 use eint::{Eint, E256, E8};
 use rvv_asm::rvv_asm;
-use rvv_testcases::intrinsic::{vop_vv, vop_vx};
-use rvv_testcases::misc::{avl_iterator, U256};
-use rvv_testcases::runner::{run_vop_vv, run_vop_vx, ExpectedOp, WideningCategory};
-
-fn expected_op(lhs: &[u8], _: u64, result: &mut [u8]) {
-    assert_eq!(lhs.len(), result.len());
-
-    match result.len() {
-        32 => {
-            let l = U256::from_little_endian(lhs);
-            let r = l << 10; // fixed
-            r.to_little_endian(result);
-        }
-        n => {
-            panic!("Invalid sew: {}", n);
-        }
-    }
-}
-
-fn test_vsll_vi(sew: u64, lmul: i64, avl: u64) {
-    fn sll(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |_| unsafe {
-            rvv_asm!("vsll.vi v24, v8, 10");
-        });
-    }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op,
-        sll,
-        WideningCategory::None,
-        "vsll.vi",
-    );
-}
-
-fn expected_op_srl_vi(lhs: &[u8], _: u64, result: &mut [u8]) {
-    assert_eq!(lhs.len(), result.len());
-
-    match result.len() {
-        32 => {
-            let l = U256::from_little_endian(lhs);
-            let r = l >> 10; // fixed
-            r.to_little_endian(result);
-        }
-        n => {
-            panic!("Invalid sew: {}", n);
-        }
-    }
-}
-
-fn test_vsrl_vi(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |_| unsafe {
-            rvv_asm!("vsrl.vi v24, v8, 10");
-        });
-    }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_srl_vi,
-        op,
-        WideningCategory::None,
-        "vsrl.vi",
-    );
-}
-
-fn expected_op_sra_vi(lhs: &[u8], _: u64, result: &mut [u8]) {
-    assert_eq!(lhs.len(), result.len());
-
-    match result.len() {
-        32 => {
-            let l = E256::get(lhs);
-            let res = l.wrapping_sra(10);
-            res.put(result);
-        }
-        n => {
-            panic!("Invalid sew: {}", n);
-        }
-    }
-}
-
-fn test_vsra_vi(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |_| unsafe {
-            rvv_asm!("vsra.vi v24, v8, 10");
-        });
-    }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_sra_vi,
-        op,
-        WideningCategory::None,
-        "vsra.vi",
-    );
-}
+use rvv_testcases::{
+    misc::{to_i64, to_u64},
+    runner::{run_template_v_vi, run_template_v_vv, run_template_v_vx, MaskType},
+};
 
 fn expected_op_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
     assert_eq!(lhs.len(), result.len());
@@ -113,6 +17,13 @@ fn expected_op_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
             let res = l.wrapping_shl(r.u32());
             res.put(result);
         }
+        8 => {
+            let l = to_i64(lhs);
+            let r = to_i64(rhs);
+
+            let res = l.wrapping_shl(r as u32);
+            result.copy_from_slice(&res.to_le_bytes());
+        }
         32 => {
             let l = E256::get(lhs);
             let r = E256::get(rhs);
@@ -124,28 +35,34 @@ fn expected_op_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vsll_vv(sew: u64, lmul: i64, avl: u64) {
-    fn sll_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vsll.vv v24, v8, v16");
-        });
+fn test_vsll_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vsll.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vsll.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_vv)),
-        sll_vv,
-        WideningCategory::None,
-        "vsll.vv",
-    );
+    run_template_v_vv(expected_op_vv, op, true, "vsll.vv");
 }
 
 fn expected_op_sra_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
     assert_eq!(lhs.len(), result.len());
 
     match result.len() {
+        8 => {
+            let l = to_i64(lhs);
+            let r = to_i64(rhs);
+
+            let res = l.wrapping_shr(r as u32);
+            result.copy_from_slice(&res.to_le_bytes());
+        }
         32 => {
             let l = E256::get(lhs);
             let r = E256::get(rhs);
@@ -157,22 +74,21 @@ fn expected_op_sra_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vsra_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vsra.vv v24, v8, v16");
-        });
+fn test_vsra_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vsra.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vsra.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_sra_vv)),
-        op,
-        WideningCategory::None,
-        "vsra.vv",
-    );
+    run_template_v_vv(expected_op_sra_vv, op, true, "vsra.vv");
 }
 
 fn expected_op_srl_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -185,6 +101,13 @@ fn expected_op_srl_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
             let res = l.wrapping_shr(r.u32());
             res.put(result);
         }
+        8 => {
+            let l = to_u64(lhs);
+            let r = to_u64(rhs);
+
+            let res = l.wrapping_shr(r as u32);
+            result.copy_from_slice(&res.to_le_bytes());
+        }
         32 => {
             let l = E256::get(lhs);
             let r = E256::get(rhs);
@@ -196,22 +119,21 @@ fn expected_op_srl_vv(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vsrl_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vsrl.vv v24, v8, v16");
-        });
+fn test_vsrl_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vsrl.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vsrl.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_srl_vv)),
-        op,
-        WideningCategory::None,
-        "vsrl.vv",
-    );
+    run_template_v_vv(expected_op_srl_vv, op, true, "vsrl.vv");
 }
 
 fn expected_op_vsll_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -219,6 +141,11 @@ fn expected_op_vsll_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
     match lhs.len() {
         1 => {
             result[0] = lhs[0] + x as u8;
+        }
+        8 => {
+            let l = to_i64(lhs);
+            let res = l.wrapping_shl(x as u32);
+            result.copy_from_slice(&res.to_le_bytes());
         }
         32 => {
             let l = E256::get(lhs);
@@ -230,29 +157,144 @@ fn expected_op_vsll_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vsll_vx(sew: u64, lmul: i64, avl: u64) {
-    fn sll_vx(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vsll.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vsll_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vsll.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vsll.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_vsll_vx,
-        sll_vx,
-        WideningCategory::None,
-        "vsll.vx",
-    );
+    run_template_v_vx(expected_op_vsll_vx, op, true, "vsll.vx");
+}
+fn test_vsll_vi() {
+    fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
+        expected_op_vsll_vx(lhs, x as u64, result);
+    }
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match imm {
+                0 => {
+                    rvv_asm!("vsll.vi v24, v8, 0");
+                }
+                1 => {
+                    rvv_asm!("vsll.vi v24, v8, 1");
+                }
+                2 => {
+                    rvv_asm!("vsll.vi v24, v8, 2");
+                }
+                3 => {
+                    rvv_asm!("vsll.vi v24, v8, 3");
+                }
+                4 => {
+                    rvv_asm!("vsll.vi v24, v8, 4");
+                }
+                5 => {
+                    rvv_asm!("vsll.vi v24, v8, 5");
+                }
+                6 => {
+                    rvv_asm!("vsll.vi v24, v8, 6");
+                }
+                7 => {
+                    rvv_asm!("vsll.vi v24, v8, 7");
+                }
+                8 => {
+                    rvv_asm!("vsll.vi v24, v8, 8");
+                }
+                9 => {
+                    rvv_asm!("vsll.vi v24, v8, 9");
+                }
+                10 => {
+                    rvv_asm!("vsll.vi v24, v8, 10");
+                }
+                11 => {
+                    rvv_asm!("vsll.vi v24, v8, 11");
+                }
+                12 => {
+                    rvv_asm!("vsll.vi v24, v8, 12");
+                }
+                13 => {
+                    rvv_asm!("vsll.vi v24, v8, 13");
+                }
+                14 => {
+                    rvv_asm!("vsll.vi v24, v8, 14");
+                }
+                15 => {
+                    rvv_asm!("vsll.vi v24, v8, 15");
+                }
+                16 => {
+                    rvv_asm!("vsll.vi v24, v8, 16");
+                }
+                17 => {
+                    rvv_asm!("vsll.vi v24, v8, 17");
+                }
+                18 => {
+                    rvv_asm!("vsll.vi v24, v8, 18");
+                }
+                19 => {
+                    rvv_asm!("vsll.vi v24, v8, 19");
+                }
+                20 => {
+                    rvv_asm!("vsll.vi v24, v8, 20");
+                }
+                21 => {
+                    rvv_asm!("vsll.vi v24, v8, 21");
+                }
+                22 => {
+                    rvv_asm!("vsll.vi v24, v8, 22");
+                }
+                23 => {
+                    rvv_asm!("vsll.vi v24, v8, 23");
+                }
+                24 => {
+                    rvv_asm!("vsll.vi v24, v8, 24");
+                }
+                25 => {
+                    rvv_asm!("vsll.vi v24, v8, 25");
+                }
+                26 => {
+                    rvv_asm!("vsll.vi v24, v8, 26");
+                }
+                27 => {
+                    rvv_asm!("vsll.vi v24, v8, 27");
+                }
+                28 => {
+                    rvv_asm!("vsll.vi v24, v8, 28");
+                }
+                29 => {
+                    rvv_asm!("vsll.vi v24, v8, 29");
+                }
+                30 => {
+                    rvv_asm!("vsll.vi v24, v8, 30");
+                }
+                31 => {
+                    rvv_asm!("vsll.vi v24, v8, 31");
+                }
+                _ => {
+                    panic!("Abort");
+                }
+            }
+        }
+    }
+    run_template_v_vi(exp_op, op, false, "vsll.vi");
 }
 
 fn expected_op_vsrl_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
     assert_eq!(lhs.len(), result.len());
     match lhs.len() {
+        8 => {
+            let l = to_u64(lhs);
+            let res = l.wrapping_shr(x as u32);
+            result.copy_from_slice(&res.to_le_bytes());
+        }
         32 => {
             let l = E256::get(lhs);
             let res = l.wrapping_shr(x as u32);
@@ -263,29 +305,144 @@ fn expected_op_vsrl_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vsrl_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vsrl.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vsrl_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vsrl.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vsrl.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_vsrl_vx,
-        op,
-        WideningCategory::None,
-        "vsrl.vx",
-    );
+    run_template_v_vx(expected_op_vsrl_vx, op, true, "vsrl.vx");
+}
+fn test_vsrl_vi() {
+    fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
+        expected_op_vsrl_vx(lhs, x as u64, result);
+    }
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match imm {
+                0 => {
+                    rvv_asm!("vsrl.vi v24, v8, 0");
+                }
+                1 => {
+                    rvv_asm!("vsrl.vi v24, v8, 1");
+                }
+                2 => {
+                    rvv_asm!("vsrl.vi v24, v8, 2");
+                }
+                3 => {
+                    rvv_asm!("vsrl.vi v24, v8, 3");
+                }
+                4 => {
+                    rvv_asm!("vsrl.vi v24, v8, 4");
+                }
+                5 => {
+                    rvv_asm!("vsrl.vi v24, v8, 5");
+                }
+                6 => {
+                    rvv_asm!("vsrl.vi v24, v8, 6");
+                }
+                7 => {
+                    rvv_asm!("vsrl.vi v24, v8, 7");
+                }
+                8 => {
+                    rvv_asm!("vsrl.vi v24, v8, 8");
+                }
+                9 => {
+                    rvv_asm!("vsrl.vi v24, v8, 9");
+                }
+                10 => {
+                    rvv_asm!("vsrl.vi v24, v8, 10");
+                }
+                11 => {
+                    rvv_asm!("vsrl.vi v24, v8, 11");
+                }
+                12 => {
+                    rvv_asm!("vsrl.vi v24, v8, 12");
+                }
+                13 => {
+                    rvv_asm!("vsrl.vi v24, v8, 13");
+                }
+                14 => {
+                    rvv_asm!("vsrl.vi v24, v8, 14");
+                }
+                15 => {
+                    rvv_asm!("vsrl.vi v24, v8, 15");
+                }
+                16 => {
+                    rvv_asm!("vsrl.vi v24, v8, 16");
+                }
+                17 => {
+                    rvv_asm!("vsrl.vi v24, v8, 17");
+                }
+                18 => {
+                    rvv_asm!("vsrl.vi v24, v8, 18");
+                }
+                19 => {
+                    rvv_asm!("vsrl.vi v24, v8, 19");
+                }
+                20 => {
+                    rvv_asm!("vsrl.vi v24, v8, 20");
+                }
+                21 => {
+                    rvv_asm!("vsrl.vi v24, v8, 21");
+                }
+                22 => {
+                    rvv_asm!("vsrl.vi v24, v8, 22");
+                }
+                23 => {
+                    rvv_asm!("vsrl.vi v24, v8, 23");
+                }
+                24 => {
+                    rvv_asm!("vsrl.vi v24, v8, 24");
+                }
+                25 => {
+                    rvv_asm!("vsrl.vi v24, v8, 25");
+                }
+                26 => {
+                    rvv_asm!("vsrl.vi v24, v8, 26");
+                }
+                27 => {
+                    rvv_asm!("vsrl.vi v24, v8, 27");
+                }
+                28 => {
+                    rvv_asm!("vsrl.vi v24, v8, 28");
+                }
+                29 => {
+                    rvv_asm!("vsrl.vi v24, v8, 29");
+                }
+                30 => {
+                    rvv_asm!("vsrl.vi v24, v8, 30");
+                }
+                31 => {
+                    rvv_asm!("vsrl.vi v24, v8, 31");
+                }
+                _ => {
+                    panic!("Abort");
+                }
+            }
+        }
+    }
+    run_template_v_vi(exp_op, op, false, "vsrl.vi");
 }
 
 fn expected_op_vsra_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
     assert_eq!(lhs.len(), result.len());
     match lhs.len() {
+        8 => {
+            let l = to_i64(lhs);
+            let res = l.wrapping_shr(x as u32);
+            result.copy_from_slice(&res.to_le_bytes());
+        }
         32 => {
             let l = E256::get(lhs);
             let res = l.wrapping_sra(x as u32);
@@ -296,41 +453,146 @@ fn expected_op_vsra_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vsra_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vsra.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vsra_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vsra.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vsra.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_vsra_vx,
-        op,
-        WideningCategory::None,
-        "vsra.vx",
-    );
+    run_template_v_vx(expected_op_vsra_vx, op, true, "vsra.vx");
+}
+fn test_vsra_vi() {
+    fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
+        expected_op_vsra_vx(lhs, x as u64, result);
+    }
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match imm {
+                0 => {
+                    rvv_asm!("vsra.vi v24, v8, 0");
+                }
+                1 => {
+                    rvv_asm!("vsra.vi v24, v8, 1");
+                }
+                2 => {
+                    rvv_asm!("vsra.vi v24, v8, 2");
+                }
+                3 => {
+                    rvv_asm!("vsra.vi v24, v8, 3");
+                }
+                4 => {
+                    rvv_asm!("vsra.vi v24, v8, 4");
+                }
+                5 => {
+                    rvv_asm!("vsra.vi v24, v8, 5");
+                }
+                6 => {
+                    rvv_asm!("vsra.vi v24, v8, 6");
+                }
+                7 => {
+                    rvv_asm!("vsra.vi v24, v8, 7");
+                }
+                8 => {
+                    rvv_asm!("vsra.vi v24, v8, 8");
+                }
+                9 => {
+                    rvv_asm!("vsra.vi v24, v8, 9");
+                }
+                10 => {
+                    rvv_asm!("vsra.vi v24, v8, 10");
+                }
+                11 => {
+                    rvv_asm!("vsra.vi v24, v8, 11");
+                }
+                12 => {
+                    rvv_asm!("vsra.vi v24, v8, 12");
+                }
+                13 => {
+                    rvv_asm!("vsra.vi v24, v8, 13");
+                }
+                14 => {
+                    rvv_asm!("vsra.vi v24, v8, 14");
+                }
+                15 => {
+                    rvv_asm!("vsra.vi v24, v8, 15");
+                }
+                16 => {
+                    rvv_asm!("vsra.vi v24, v8, 16");
+                }
+                17 => {
+                    rvv_asm!("vsra.vi v24, v8, 17");
+                }
+                18 => {
+                    rvv_asm!("vsra.vi v24, v8, 18");
+                }
+                19 => {
+                    rvv_asm!("vsra.vi v24, v8, 19");
+                }
+                20 => {
+                    rvv_asm!("vsra.vi v24, v8, 20");
+                }
+                21 => {
+                    rvv_asm!("vsra.vi v24, v8, 21");
+                }
+                22 => {
+                    rvv_asm!("vsra.vi v24, v8, 22");
+                }
+                23 => {
+                    rvv_asm!("vsra.vi v24, v8, 23");
+                }
+                24 => {
+                    rvv_asm!("vsra.vi v24, v8, 24");
+                }
+                25 => {
+                    rvv_asm!("vsra.vi v24, v8, 25");
+                }
+                26 => {
+                    rvv_asm!("vsra.vi v24, v8, 26");
+                }
+                27 => {
+                    rvv_asm!("vsra.vi v24, v8, 27");
+                }
+                28 => {
+                    rvv_asm!("vsra.vi v24, v8, 28");
+                }
+                29 => {
+                    rvv_asm!("vsra.vi v24, v8, 29");
+                }
+                30 => {
+                    rvv_asm!("vsra.vi v24, v8, 30");
+                }
+                31 => {
+                    rvv_asm!("vsra.vi v24, v8, 31");
+                }
+                _ => {
+                    panic!("Abort");
+                }
+            }
+        }
+    }
+    run_template_v_vi(exp_op, op, false, "vsra.vi");
 }
 
 pub fn test_single_width_shift() {
-    let sew = 256u64;
-    for lmul in [-2, 1, 4, 8] {
-        for avl in avl_iterator(sew, 4) {
-            test_vsll_vi(sew, lmul, avl);
-            test_vsll_vv(sew, lmul, avl);
-            test_vsll_vx(sew, lmul, avl);
+    test_vsll_vv();
+    test_vsll_vx();
+    test_vsll_vi();
 
-            test_vsrl_vi(sew, lmul, avl);
-            test_vsrl_vv(sew, lmul, avl);
-            test_vsrl_vx(sew, lmul, avl);
+    test_vsrl_vv();
+    test_vsrl_vx();
+    test_vsrl_vi();
 
-            test_vsra_vi(sew, lmul, avl);
-            test_vsra_vv(sew, lmul, avl);
-            test_vsra_vx(sew, lmul, avl);
-        }
-    }
+    test_vsra_vv();
+    test_vsra_vx();
+    test_vsra_vi();
 }

--- a/cases/src/single_width_shift_cases.rs
+++ b/cases/src/single_width_shift_cases.rs
@@ -178,113 +178,306 @@ fn test_vsll_vi() {
     fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
         expected_op_vsll_vx(lhs, x as u64, result);
     }
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                0 => {
-                    rvv_asm!("vsll.vi v24, v8, 0");
-                }
-                1 => {
-                    rvv_asm!("vsll.vi v24, v8, 1");
-                }
-                2 => {
-                    rvv_asm!("vsll.vi v24, v8, 2");
-                }
-                3 => {
-                    rvv_asm!("vsll.vi v24, v8, 3");
-                }
-                4 => {
-                    rvv_asm!("vsll.vi v24, v8, 4");
-                }
-                5 => {
-                    rvv_asm!("vsll.vi v24, v8, 5");
-                }
-                6 => {
-                    rvv_asm!("vsll.vi v24, v8, 6");
-                }
-                7 => {
-                    rvv_asm!("vsll.vi v24, v8, 7");
-                }
-                8 => {
-                    rvv_asm!("vsll.vi v24, v8, 8");
-                }
-                9 => {
-                    rvv_asm!("vsll.vi v24, v8, 9");
-                }
-                10 => {
-                    rvv_asm!("vsll.vi v24, v8, 10");
-                }
-                11 => {
-                    rvv_asm!("vsll.vi v24, v8, 11");
-                }
-                12 => {
-                    rvv_asm!("vsll.vi v24, v8, 12");
-                }
-                13 => {
-                    rvv_asm!("vsll.vi v24, v8, 13");
-                }
-                14 => {
-                    rvv_asm!("vsll.vi v24, v8, 14");
-                }
-                15 => {
-                    rvv_asm!("vsll.vi v24, v8, 15");
-                }
-                16 => {
-                    rvv_asm!("vsll.vi v24, v8, 16");
-                }
-                17 => {
-                    rvv_asm!("vsll.vi v24, v8, 17");
-                }
-                18 => {
-                    rvv_asm!("vsll.vi v24, v8, 18");
-                }
-                19 => {
-                    rvv_asm!("vsll.vi v24, v8, 19");
-                }
-                20 => {
-                    rvv_asm!("vsll.vi v24, v8, 20");
-                }
-                21 => {
-                    rvv_asm!("vsll.vi v24, v8, 21");
-                }
-                22 => {
-                    rvv_asm!("vsll.vi v24, v8, 22");
-                }
-                23 => {
-                    rvv_asm!("vsll.vi v24, v8, 23");
-                }
-                24 => {
-                    rvv_asm!("vsll.vi v24, v8, 24");
-                }
-                25 => {
-                    rvv_asm!("vsll.vi v24, v8, 25");
-                }
-                26 => {
-                    rvv_asm!("vsll.vi v24, v8, 26");
-                }
-                27 => {
-                    rvv_asm!("vsll.vi v24, v8, 27");
-                }
-                28 => {
-                    rvv_asm!("vsll.vi v24, v8, 28");
-                }
-                29 => {
-                    rvv_asm!("vsll.vi v24, v8, 29");
-                }
-                30 => {
-                    rvv_asm!("vsll.vi v24, v8, 30");
-                }
-                31 => {
-                    rvv_asm!("vsll.vi v24, v8, 31");
-                }
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                17 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 17, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 17");
+                    }
+                    _ => panic!("Abort"),
+                },
+                18 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 18, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 18");
+                    }
+                    _ => panic!("Abort"),
+                },
+                19 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 19, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 19");
+                    }
+                    _ => panic!("Abort"),
+                },
+                20 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 20, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 20");
+                    }
+                    _ => panic!("Abort"),
+                },
+                21 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 21, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 21");
+                    }
+                    _ => panic!("Abort"),
+                },
+                22 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 22, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 22");
+                    }
+                    _ => panic!("Abort"),
+                },
+                23 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 23, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 23");
+                    }
+                    _ => panic!("Abort"),
+                },
+                24 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 24, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 24");
+                    }
+                    _ => panic!("Abort"),
+                },
+                25 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 25, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 25");
+                    }
+                    _ => panic!("Abort"),
+                },
+                26 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 26, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 26");
+                    }
+                    _ => panic!("Abort"),
+                },
+                27 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 27, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 27");
+                    }
+                    _ => panic!("Abort"),
+                },
+                28 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 28, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 28");
+                    }
+                    _ => panic!("Abort"),
+                },
+                29 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 29, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 29");
+                    }
+                    _ => panic!("Abort"),
+                },
+                30 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 30, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 30");
+                    }
+                    _ => panic!("Abort"),
+                },
+                31 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsll.vi v24, v8, 31, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsll.vi v24, v8, 31");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
                     panic!("Abort");
                 }
             }
         }
     }
-    run_template_v_vi(exp_op, op, false, "vsll.vi");
+
+    run_template_v_vi(exp_op, op, true, false, "vsll.vi");
 }
 
 fn expected_op_vsrl_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -326,113 +519,305 @@ fn test_vsrl_vi() {
     fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
         expected_op_vsrl_vx(lhs, x as u64, result);
     }
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                0 => {
-                    rvv_asm!("vsrl.vi v24, v8, 0");
-                }
-                1 => {
-                    rvv_asm!("vsrl.vi v24, v8, 1");
-                }
-                2 => {
-                    rvv_asm!("vsrl.vi v24, v8, 2");
-                }
-                3 => {
-                    rvv_asm!("vsrl.vi v24, v8, 3");
-                }
-                4 => {
-                    rvv_asm!("vsrl.vi v24, v8, 4");
-                }
-                5 => {
-                    rvv_asm!("vsrl.vi v24, v8, 5");
-                }
-                6 => {
-                    rvv_asm!("vsrl.vi v24, v8, 6");
-                }
-                7 => {
-                    rvv_asm!("vsrl.vi v24, v8, 7");
-                }
-                8 => {
-                    rvv_asm!("vsrl.vi v24, v8, 8");
-                }
-                9 => {
-                    rvv_asm!("vsrl.vi v24, v8, 9");
-                }
-                10 => {
-                    rvv_asm!("vsrl.vi v24, v8, 10");
-                }
-                11 => {
-                    rvv_asm!("vsrl.vi v24, v8, 11");
-                }
-                12 => {
-                    rvv_asm!("vsrl.vi v24, v8, 12");
-                }
-                13 => {
-                    rvv_asm!("vsrl.vi v24, v8, 13");
-                }
-                14 => {
-                    rvv_asm!("vsrl.vi v24, v8, 14");
-                }
-                15 => {
-                    rvv_asm!("vsrl.vi v24, v8, 15");
-                }
-                16 => {
-                    rvv_asm!("vsrl.vi v24, v8, 16");
-                }
-                17 => {
-                    rvv_asm!("vsrl.vi v24, v8, 17");
-                }
-                18 => {
-                    rvv_asm!("vsrl.vi v24, v8, 18");
-                }
-                19 => {
-                    rvv_asm!("vsrl.vi v24, v8, 19");
-                }
-                20 => {
-                    rvv_asm!("vsrl.vi v24, v8, 20");
-                }
-                21 => {
-                    rvv_asm!("vsrl.vi v24, v8, 21");
-                }
-                22 => {
-                    rvv_asm!("vsrl.vi v24, v8, 22");
-                }
-                23 => {
-                    rvv_asm!("vsrl.vi v24, v8, 23");
-                }
-                24 => {
-                    rvv_asm!("vsrl.vi v24, v8, 24");
-                }
-                25 => {
-                    rvv_asm!("vsrl.vi v24, v8, 25");
-                }
-                26 => {
-                    rvv_asm!("vsrl.vi v24, v8, 26");
-                }
-                27 => {
-                    rvv_asm!("vsrl.vi v24, v8, 27");
-                }
-                28 => {
-                    rvv_asm!("vsrl.vi v24, v8, 28");
-                }
-                29 => {
-                    rvv_asm!("vsrl.vi v24, v8, 29");
-                }
-                30 => {
-                    rvv_asm!("vsrl.vi v24, v8, 30");
-                }
-                31 => {
-                    rvv_asm!("vsrl.vi v24, v8, 31");
-                }
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                17 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 17, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 17");
+                    }
+                    _ => panic!("Abort"),
+                },
+                18 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 18, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 18");
+                    }
+                    _ => panic!("Abort"),
+                },
+                19 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 19, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 19");
+                    }
+                    _ => panic!("Abort"),
+                },
+                20 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 20, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 20");
+                    }
+                    _ => panic!("Abort"),
+                },
+                21 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 21, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 21");
+                    }
+                    _ => panic!("Abort"),
+                },
+                22 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 22, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 22");
+                    }
+                    _ => panic!("Abort"),
+                },
+                23 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 23, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 23");
+                    }
+                    _ => panic!("Abort"),
+                },
+                24 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 24, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 24");
+                    }
+                    _ => panic!("Abort"),
+                },
+                25 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 25, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 25");
+                    }
+                    _ => panic!("Abort"),
+                },
+                26 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 26, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 26");
+                    }
+                    _ => panic!("Abort"),
+                },
+                27 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 27, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 27");
+                    }
+                    _ => panic!("Abort"),
+                },
+                28 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 28, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 28");
+                    }
+                    _ => panic!("Abort"),
+                },
+                29 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 29, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 29");
+                    }
+                    _ => panic!("Abort"),
+                },
+                30 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 30, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 30");
+                    }
+                    _ => panic!("Abort"),
+                },
+                31 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsrl.vi v24, v8, 31, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsrl.vi v24, v8, 31");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
                     panic!("Abort");
                 }
             }
         }
     }
-    run_template_v_vi(exp_op, op, false, "vsrl.vi");
+    run_template_v_vi(exp_op, op, true, false, "vsrl.vi");
 }
 
 fn expected_op_vsra_vx(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -474,113 +859,306 @@ fn test_vsra_vi() {
     fn exp_op(lhs: &[u8], x: i64, result: &mut [u8]) {
         expected_op_vsra_vx(lhs, x as u64, result);
     }
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                0 => {
-                    rvv_asm!("vsra.vi v24, v8, 0");
-                }
-                1 => {
-                    rvv_asm!("vsra.vi v24, v8, 1");
-                }
-                2 => {
-                    rvv_asm!("vsra.vi v24, v8, 2");
-                }
-                3 => {
-                    rvv_asm!("vsra.vi v24, v8, 3");
-                }
-                4 => {
-                    rvv_asm!("vsra.vi v24, v8, 4");
-                }
-                5 => {
-                    rvv_asm!("vsra.vi v24, v8, 5");
-                }
-                6 => {
-                    rvv_asm!("vsra.vi v24, v8, 6");
-                }
-                7 => {
-                    rvv_asm!("vsra.vi v24, v8, 7");
-                }
-                8 => {
-                    rvv_asm!("vsra.vi v24, v8, 8");
-                }
-                9 => {
-                    rvv_asm!("vsra.vi v24, v8, 9");
-                }
-                10 => {
-                    rvv_asm!("vsra.vi v24, v8, 10");
-                }
-                11 => {
-                    rvv_asm!("vsra.vi v24, v8, 11");
-                }
-                12 => {
-                    rvv_asm!("vsra.vi v24, v8, 12");
-                }
-                13 => {
-                    rvv_asm!("vsra.vi v24, v8, 13");
-                }
-                14 => {
-                    rvv_asm!("vsra.vi v24, v8, 14");
-                }
-                15 => {
-                    rvv_asm!("vsra.vi v24, v8, 15");
-                }
-                16 => {
-                    rvv_asm!("vsra.vi v24, v8, 16");
-                }
-                17 => {
-                    rvv_asm!("vsra.vi v24, v8, 17");
-                }
-                18 => {
-                    rvv_asm!("vsra.vi v24, v8, 18");
-                }
-                19 => {
-                    rvv_asm!("vsra.vi v24, v8, 19");
-                }
-                20 => {
-                    rvv_asm!("vsra.vi v24, v8, 20");
-                }
-                21 => {
-                    rvv_asm!("vsra.vi v24, v8, 21");
-                }
-                22 => {
-                    rvv_asm!("vsra.vi v24, v8, 22");
-                }
-                23 => {
-                    rvv_asm!("vsra.vi v24, v8, 23");
-                }
-                24 => {
-                    rvv_asm!("vsra.vi v24, v8, 24");
-                }
-                25 => {
-                    rvv_asm!("vsra.vi v24, v8, 25");
-                }
-                26 => {
-                    rvv_asm!("vsra.vi v24, v8, 26");
-                }
-                27 => {
-                    rvv_asm!("vsra.vi v24, v8, 27");
-                }
-                28 => {
-                    rvv_asm!("vsra.vi v24, v8, 28");
-                }
-                29 => {
-                    rvv_asm!("vsra.vi v24, v8, 29");
-                }
-                30 => {
-                    rvv_asm!("vsra.vi v24, v8, 30");
-                }
-                31 => {
-                    rvv_asm!("vsra.vi v24, v8, 31");
-                }
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                17 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 17, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 17");
+                    }
+                    _ => panic!("Abort"),
+                },
+                18 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 18, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 18");
+                    }
+                    _ => panic!("Abort"),
+                },
+                19 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 19, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 19");
+                    }
+                    _ => panic!("Abort"),
+                },
+                20 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 20, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 20");
+                    }
+                    _ => panic!("Abort"),
+                },
+                21 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 21, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 21");
+                    }
+                    _ => panic!("Abort"),
+                },
+                22 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 22, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 22");
+                    }
+                    _ => panic!("Abort"),
+                },
+                23 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 23, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 23");
+                    }
+                    _ => panic!("Abort"),
+                },
+                24 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 24, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 24");
+                    }
+                    _ => panic!("Abort"),
+                },
+                25 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 25, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 25");
+                    }
+                    _ => panic!("Abort"),
+                },
+                26 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 26, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 26");
+                    }
+                    _ => panic!("Abort"),
+                },
+                27 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 27, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 27");
+                    }
+                    _ => panic!("Abort"),
+                },
+                28 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 28, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 28");
+                    }
+                    _ => panic!("Abort"),
+                },
+                29 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 29, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 29");
+                    }
+                    _ => panic!("Abort"),
+                },
+                30 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 30, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 30");
+                    }
+                    _ => panic!("Abort"),
+                },
+                31 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vsra.vi v24, v8, 31, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vsra.vi v24, v8, 31");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
                     panic!("Abort");
                 }
             }
         }
     }
-    run_template_v_vi(exp_op, op, false, "vsra.vi");
+
+    run_template_v_vi(exp_op, op, true, false, "vsra.vi");
 }
 
 pub fn test_single_width_shift() {

--- a/cases/src/vector_register_gather_cases.rs
+++ b/cases/src/vector_register_gather_cases.rs
@@ -1,249 +1,147 @@
 use alloc::vec::Vec;
 use core::arch::asm;
 use core::convert::TryInto;
-use rand::Rng;
 use rvv_asm::rvv_asm;
 
-use ckb_std::syscalls::debug;
-use rvv_testcases::intrinsic::{vs1r_v24, vsetvl};
-use rvv_testcases::log;
-use rvv_testcases::misc::{get_bit_in_slice, is_verbose, U1024, U256, U512, VLEN};
-use rvv_testcases::rng::BestNumberRng;
-use rvv_testcases::runner::{run_template, ExpectedParam, InstructionArgsType, MaskType};
+use eint::{Eint, E256};
+use rvv_testcases::runner::{run_template, RVVTestData, InstructionArgsType, MaskType};
 
-fn to_wide(vs1: &[u8], wide: usize) -> Vec<u32> {
-    let wide = wide / 8;
-    let mut ret: Vec<u32> = Vec::new();
-    ret.resize(vs1.len() / wide, 0);
-    for i in 0..vs1.len() / wide {
-        ret[i] = match wide {
-            1 => vs1[i] as u32,
-            2 => u16::from_le_bytes(vs1[i * wide..i * wide + 2].try_into().unwrap()) as u32,
-            4 => u32::from_le_bytes(vs1[i * wide..i * wide + 4].try_into().unwrap()),
-            8 => {
-                let d = u64::from_le_bytes(vs1[i * wide..i * wide + 8].try_into().unwrap());
-                if d >= 0xFFFF {
-                    0xFFFF as u32
-                } else {
-                    d as u32
-                }
-            }
-            16 => {
-                let d = u128::from_le_bytes(vs1[i * wide..i * wide + 16].try_into().unwrap());
-                if d >= 0xFFFF {
-                    0xFFFF as u32
-                } else {
-                    d as u32
-                }
-            }
-            32 => {
-                let d = U256::from_little_endian(vs1[i * wide..i * wide + 32].try_into().unwrap());
-                if d >= 0xFFFF.into() {
-                    0xFFFF as u32
-                } else {
-                    d.as_u32()
-                }
-            }
-            64 => {
-                let d = U512::from_little_endian(vs1[i * wide..i * wide + 64].try_into().unwrap());
-                if d >= 0xFFFF.into() {
-                    0xFFFF as u32
-                } else {
-                    d.as_u32()
-                }
-            }
-            128 => {
-                let d = U512::from_little_endian(vs1[i * wide..i * wide + 128].try_into().unwrap());
-                if d >= 0xFFFF.into() {
-                    0xFFFF as u32
-                } else {
-                    d.as_u32()
-                }
-            }
-            256 => {
-                let d =
-                    U1024::from_little_endian(vs1[i * wide..i * wide + 256].try_into().unwrap());
-                if d >= 0xFFFF.into() {
-                    0xFFFF as u32
-                } else {
-                    d.as_u32()
-                }
-            }
-            _ => {
-                assert!(false);
-                0
-            }
-        };
-    }
-    ret
-}
-
-fn rgather_vv(
-    vd: &[u8],
-    v2: &[u8],
-    v8: &[u8],
-    vm: &[u8],
-    enable_mask: bool,
-    wide: usize,
-    v8_wide: usize,
-) -> Vec<u8> {
-    let mut result: Vec<u8> = Vec::new();
-    result.resize(vd.len(), 0);
-    result.copy_from_slice(vd);
-
-    let v8 = to_wide(v8, v8_wide);
-
-    let wide = wide / 8;
-    for i in 0..(vd.len() / wide) {
-        if enable_mask && get_bit_in_slice(vm, i) == 0 {
-            continue;
-        }
-
-        let index = v8[i];
-        let pos = index as usize * wide;
-
-        if pos >= vd.len() {
-            for j in 0..wide {
-                result[i * wide + j] = 0;
-            }
-        } else {
-            result[i * wide..(i + 1) * wide].copy_from_slice(&v2[pos..pos + wide]);
-        }
-    }
-
-    result
-}
-
-fn vrgather_vv(wide: usize, enable_mask: bool, enable_ei16: bool) {
-    let mut mask = [0u8; VLEN / 8];
-    let mut expected_before = [0u8; VLEN / 8];
-    let mut vs1 = [0u8; VLEN / 4];
-    let mut vs2 = [0u8; VLEN / 8];
-    let mut result = [0u8; VLEN / 8];
-
-    let mut rng = BestNumberRng::default();
-
-    rng.fill(&mut mask[..]);
-    rng.fill(&mut vs1[..]);
-    rng.fill(&mut vs2[..]);
-    rng.fill(&mut expected_before[..]);
-    if !enable_mask {
-        mask = [0; VLEN / 8];
-    }
-
-    let expected = if enable_ei16 {
-        rgather_vv(&expected_before, &vs2, &vs1, &mask, enable_mask, wide, 16)
-    } else {
-        rgather_vv(&expected_before, &vs2, &vs1, &mask, enable_mask, wide, wide)
-    };
-    let expected = expected.as_slice();
-
-    let vl = vsetvl((VLEN / wide) as u64, wide as u64, 1) as usize;
-    assert_eq!(vl, VLEN / wide);
-
-    unsafe {
-        rvv_asm!(
-            "mv t0, {}", "vl1re8.v v0, (t0)",
-            "mv t0, {}", "vl1re8.v v8, (t0)",
-            "mv t0, {}", "vl1re8.v v4, (t0)",
-            "mv t0, {}", "vl1re8.v v5, (t0)",
-            "mv t0, {}", "vl1re8.v v24, (t0)",
-            in (reg) mask.as_ptr(),
-            in (reg) vs2.as_ptr(),
-            in (reg) vs1.as_ptr(),
-            in (reg) vs1[256..].as_ptr(),
-            in (reg) expected_before.as_ptr());
-
-        if enable_ei16 {
-            if enable_mask {
-                rvv_asm!("vrgatherei16.vv v24, v8, v4, v0.t");
-            } else {
-                rvv_asm!("vrgatherei16.vv v24, v8, v4");
-            }
-        } else {
-            if enable_mask {
-                rvv_asm!("vrgather.vv v24, v8, v4, v0.t");
-            } else {
-                rvv_asm!("vrgather.vv v24, v8, v4");
-            }
-        }
-
-        vs1r_v24(&mut result);
-    }
-
-    if result != expected {
-        log!(
-            "[describe = vrgather.vv] unexpected values found: \nresult = {:0>2X?} \nexpected = {:0>2X?}",
-            result,
-            expected
-        );
-        log!(
-            "more information, \nvs1 = {:0>2X?}, \nvs2 = {:0>2X?}, \nmask = {:0>2X?}, \nexpected_befor = {:0>2X?}, enable_mask = {}, enable_ei16 = {}, \nwide = {}",
-            vs1,
-            vs2,
-            mask,
-            expected_before,
-            enable_mask,
-            enable_ei16,
-            wide
-        );
-        panic!("Abort");
-    }
-    if is_verbose() {
-        log!("finished");
-    }
-}
-
-pub fn test_vrgather_vv() {
-    if is_verbose() {
-        log!("test vrgather.vv");
-    }
-
-    vrgather_vv(8, false, false);
-    vrgather_vv(16, false, false);
-    vrgather_vv(128, false, false);
-
-    vrgather_vv(8, true, false);
-    vrgather_vv(16, true, false);
-    vrgather_vv(128, true, false);
-}
-
-pub fn test_vrgatherei16_vv() {
-    if is_verbose() {
-        log!("test vrgatherei16.vv");
-    }
-
-    vrgather_vv(8, false, true);
-    vrgather_vv(16, false, true);
-    vrgather_vv(128, false, true);
-
-    vrgather_vv(8, true, true);
-    vrgather_vv(16, true, true);
-    vrgather_vv(128, true, true);
-}
+// use rvv_testcases::log;
+// use ckb_std::syscalls::debug;
 
 static mut ZERO_BUFFER: Vec<u8> = Vec::new();
 
-fn expected_op_vrgather(exp_param: &mut ExpectedParam) {
-    let x = exp_param.get_right_u64() as usize % 31;
-    if (x + 1) > exp_param.get_vl() {
+fn alway_true(_: f64, _: f64, _: u64) -> bool {
+    true
+}
+
+fn expected_op_vrgather(rvv_data: &mut RVVTestData) {
+    let x = rvv_data.get_right_u64() as usize % 32;
+    if (x + 1) > rvv_data.get_vl() {
         unsafe {
-            exp_param.set_result(&ZERO_BUFFER[..exp_param.sew_bytes]);
+            rvv_data.set_result_exp(&ZERO_BUFFER[..rvv_data.sew_bytes]);
         }
     } else {
-        let data = ExpectedParam::get_data_by_sclice(
-            &exp_param.lhs,
-            exp_param.lhs_type,
-            exp_param.sew_bytes,
-            exp_param.count * exp_param.theoretically_vl + x,
+        let data = rvv_data.get_data(
+            &rvv_data.lhs,
+            rvv_data.lhs_type,
+            rvv_data.count * rvv_data.theoretically_vl + x,
         );
-        exp_param.set_result(&data);
+        rvv_data.set_result_exp(&data);
     }
+}
+
+fn test_vrgather_vv() {
+    fn expected_op(rvv_data: &mut RVVTestData) {
+        let rhs = rvv_data.get_right();
+        let x = match rhs.len() {
+            8 => u64::from_le_bytes(rhs.try_into().unwrap()),
+            32 => {
+                let r = E256::get(&rhs);
+                if r >= E256::from(0xffff) {
+                    0xffffu64
+                } else {
+                    r.u64()
+                }
+            }
+            _ => panic!("Abort"),
+        } as usize;
+
+        let (x_end, overflow) = x.overflowing_add(1);
+        if overflow || x_end > rvv_data.get_vl() {
+            unsafe {
+                rvv_data.set_result_exp(&ZERO_BUFFER[..rvv_data.sew_bytes]);
+            }
+        } else {
+            let data = rvv_data.get_data(
+                &rvv_data.lhs,
+                rvv_data.lhs_type,
+                rvv_data.count * rvv_data.theoretically_vl + x,
+            );
+            rvv_data.set_result_exp(&data);
+        }
+    }
+    fn rvv_op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vrgather.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vrgather.vv v24, v8, v16, v0");
+                }
+                _ => panic!("Abort"),
+            };
+        }
+    }
+
+    run_template(
+        InstructionArgsType::Vector,
+        InstructionArgsType::Vector,
+        InstructionArgsType::Vector,
+        MaskType::Enable,
+        expected_op,
+        rvv_op,
+        alway_true,
+        "vrgather.vv",
+    );
+}
+
+fn test_vrgather16_vv() {
+    fn expected_op(rvv_data: &mut RVVTestData) {
+        let rhs = rvv_data.get_right();
+        let x = u16::from_le_bytes(rhs.try_into().unwrap()) as usize;
+
+        if (x + 1) > rvv_data.get_vl() {
+            unsafe {
+                rvv_data.set_result_exp(&ZERO_BUFFER[..rvv_data.sew_bytes]);
+            }
+            //log!("-- index: {} set zero", rvv_data.index);
+        } else {
+            let data = rvv_data.get_data(
+                &rvv_data.lhs,
+                rvv_data.lhs_type,
+                rvv_data.count * rvv_data.theoretically_vl + x,
+            );
+            rvv_data.set_result_exp(&data);
+            //log!("-- index: {}, count: {}, x: {}, data: {:0>2X?}", rvv_data.index, rvv_data.count, x, data);
+
+        }
+    }
+    fn rvv_op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vrgatherei16.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vrgatherei16.vv v24, v8, v16, v0");
+                }
+                _ => panic!("Abort"),
+            };
+        }
+    }
+
+    fn before_op(sew: f64, lmul: f64, _: u64) -> bool {
+        let emul = 16.0 / sew as f64 * lmul;
+        emul >= 0.125 && emul <= 8.0
+    }
+
+    run_template(
+        InstructionArgsType::Vector,
+        InstructionArgsType::Vector,
+        InstructionArgsType::VectorAlway16,
+        MaskType::Enable,
+        expected_op,
+        rvv_op,
+        before_op,
+        "vrgatherei16.vv",
+    );
 }
 
 fn test_vrgather_vx() {
     fn rvv_op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
-        let x = u64::from_le_bytes(rhs.try_into().unwrap()) % 31;
+        let x = u64::from_le_bytes(rhs.try_into().unwrap()) % 32;
 
         unsafe {
             match mask_type {
@@ -265,8 +163,7 @@ fn test_vrgather_vx() {
         MaskType::Enable,
         expected_op_vrgather,
         rvv_op,
-        &[64, 256],
-        &[-8, -2, 1, 4, 8],
+        alway_true,
         "vrgather.vx",
     );
 }
@@ -387,16 +284,17 @@ fn test_vrgather_vi() {
         MaskType::Disable,
         expected_op_vrgather,
         rvv_op,
-        &[64, 256],
-        &[-8, -2, 1, 4, 8],
+        alway_true,
         "vrgather.vi",
     );
 }
 
-pub fn test_vrgatherer_vx() {
+pub fn test_vrgatherer() {
     unsafe {
         ZERO_BUFFER.resize(128, 0);
     }
     test_vrgather_vx();
+    test_vrgather16_vv();
     test_vrgather_vi();
+    test_vrgather_vv();
 }

--- a/cases/src/vmsop_vi_cases.rs
+++ b/cases/src/vmsop_vi_cases.rs
@@ -2,39 +2,30 @@ use core::{arch::asm, convert::TryInto};
 use eint::{Eint, E128, E256};
 use rvv_asm::rvv_asm;
 use rvv_testcases::{
-    intrinsic::vmsop_vi,
-    misc::{avl_iterator, conver_to_i256, set_bit_in_slice},
-    runner::{run_vmsop_vi, WideningCategory},
+    misc::conver_to_i256,
+    runner::{run_template_m_vi, MaskType},
 };
 
-fn expected_eq(lhs: &[u8], imm: i64, result: &mut [u8], index: usize) {
-    let res = match lhs.len() {
+fn expected_eq(lhs: &[u8], imm: i64, result: &mut bool) {
+    match lhs.len() {
         8 => {
             let l = i64::from_le_bytes(lhs.try_into().unwrap());
-            if l == imm as i64 {
-                1
-            } else {
-                0
-            }
+            *result = l == imm as i64;
         }
         32 => {
             let l = E256::get(lhs);
             let r = conver_to_i256(E128::from(imm as i128));
-            if l == r {
-                1
-            } else {
-                0
-            }
+            *result = l == r;
         }
         _ => {
             panic!("Invalid sew");
         }
     };
-    set_bit_in_slice(result, index, res);
 }
-fn test_vmseq(sew: u64, lmul: i64, avl: u64, imm: i64) {
-    fn op(lhs: &[u8], imm: i64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vi(lhs, imm, result, sew, avl, lmul, |imm| unsafe {
+fn test_vmseq() {
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
             match imm {
                 -16 => {
                     rvv_asm!("vmseq.vi v24, v8, -16");
@@ -136,48 +127,31 @@ fn test_vmseq(sew: u64, lmul: i64, avl: u64, imm: i64) {
                     panic!("Invalid immediate: {}", imm);
                 }
             }
-        });
+        }
     }
-    run_vmsop_vi(
-        sew,
-        lmul,
-        avl,
-        imm,
-        expected_eq,
-        op,
-        WideningCategory::None,
-        "vmseq.vi",
-    );
+    run_template_m_vi(expected_eq, op, false, "vmseq.vi");
 }
 
-fn expected_ne(lhs: &[u8], imm: i64, result: &mut [u8], index: usize) {
-    let res = match lhs.len() {
+fn expected_ne(lhs: &[u8], imm: i64, result: &mut bool) {
+    match lhs.len() {
         8 => {
             let l = i64::from_le_bytes(lhs.try_into().unwrap());
-            if l != imm as i64 {
-                1
-            } else {
-                0
-            }
+            *result = l != imm as i64;
         }
         32 => {
             let l = E256::get(lhs);
             let r = conver_to_i256(E128::from(imm as i128));
-            if l != r {
-                1
-            } else {
-                0
-            }
+            *result = l != r;
         }
         _ => {
             panic!("Invalid sew");
         }
     };
-    set_bit_in_slice(result, index, res);
 }
-fn test_vmsne(sew: u64, lmul: i64, avl: u64, imm: i64) {
-    fn op(lhs: &[u8], imm: i64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vi(lhs, imm, result, sew, avl, lmul, |imm| unsafe {
+fn test_vmsne() {
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
             match imm {
                 -16 => {
                     rvv_asm!("vmsne.vi v24, v8, -16");
@@ -279,48 +253,31 @@ fn test_vmsne(sew: u64, lmul: i64, avl: u64, imm: i64) {
                     panic!("Invalid immediate: {}", imm);
                 }
             }
-        });
+        }
     }
-    run_vmsop_vi(
-        sew,
-        lmul,
-        avl,
-        imm,
-        expected_ne,
-        op,
-        WideningCategory::None,
-        "vmsne.vi",
-    );
+    run_template_m_vi(expected_ne, op, false, "vmsne.vi");
 }
 
-fn expected_leu(lhs: &[u8], imm: i64, result: &mut [u8], index: usize) {
-    let res = match lhs.len() {
+fn expected_leu(lhs: &[u8], imm: i64, result: &mut bool) {
+    match lhs.len() {
         8 => {
             let l = u64::from_le_bytes(lhs.try_into().unwrap());
-            if l <= imm as u64 {
-                1
-            } else {
-                0
-            }
+            *result = l <= imm as u64;
         }
         32 => {
             let l = E256::get(lhs);
             let r = E256::from(imm);
-            if l.cmp_u(&r).is_le() {
-                1
-            } else {
-                0
-            }
+            *result = l.cmp_u(&r).is_le();
         }
         _ => {
             panic!("Invalid sew");
         }
     };
-    set_bit_in_slice(result, index, res);
 }
-fn test_vmsleu(sew: u64, lmul: i64, avl: u64, imm: i64) {
-    fn op(lhs: &[u8], imm: i64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vi(lhs, imm, result, sew, avl, lmul, |imm| unsafe {
+fn test_vmsleu() {
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
             match imm {
                 -16 => {
                     rvv_asm!("vmsleu.vi v24, v8, -16");
@@ -422,48 +379,31 @@ fn test_vmsleu(sew: u64, lmul: i64, avl: u64, imm: i64) {
                     panic!("Invalid immediate: {}", imm);
                 }
             }
-        });
+        }
     }
-    run_vmsop_vi(
-        sew,
-        lmul,
-        avl,
-        imm,
-        expected_leu,
-        op,
-        WideningCategory::None,
-        "vmsleu.vi",
-    );
+    run_template_m_vi(expected_leu, op, false, "vmsleu.vi");
 }
 
-fn expected_le(lhs: &[u8], imm: i64, result: &mut [u8], index: usize) {
-    let res = match lhs.len() {
+fn expected_le(lhs: &[u8], imm: i64, result: &mut bool) {
+    match lhs.len() {
         8 => {
             let l = i64::from_le_bytes(lhs.try_into().unwrap());
-            if l <= imm as i64 {
-                1
-            } else {
-                0
-            }
+            *result = l <= imm as i64;
         }
         32 => {
             let l = E256::get(lhs);
             let r = conver_to_i256(E128::from(imm as i128));
-            if l.cmp_s(&r).is_le() {
-                1
-            } else {
-                0
-            }
+            *result = l.cmp_s(&r).is_le();
         }
         _ => {
             panic!("Invalid sew");
         }
     };
-    set_bit_in_slice(result, index, res);
 }
-fn test_vmsle(sew: u64, lmul: i64, avl: u64, imm: i64) {
-    fn op(lhs: &[u8], imm: i64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vi(lhs, imm, result, sew, avl, lmul, |imm| unsafe {
+fn test_vmsle() {
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
             match imm {
                 -16 => {
                     rvv_asm!("vmsle.vi v24, v8, -16");
@@ -565,48 +505,31 @@ fn test_vmsle(sew: u64, lmul: i64, avl: u64, imm: i64) {
                     panic!("Invalid immediate: {}", imm);
                 }
             }
-        });
+        }
     }
-    run_vmsop_vi(
-        sew,
-        lmul,
-        avl,
-        imm,
-        expected_le,
-        op,
-        WideningCategory::None,
-        "vmsle.vi",
-    );
+    run_template_m_vi(expected_le, op, false, "vmsle.vi");
 }
 
-fn expected_gtu(lhs: &[u8], imm: i64, result: &mut [u8], index: usize) {
-    let res = match lhs.len() {
+fn expected_gtu(lhs: &[u8], imm: i64, result: &mut bool) {
+    match lhs.len() {
         8 => {
             let l = u64::from_le_bytes(lhs.try_into().unwrap());
-            if l > imm as u64 {
-                1
-            } else {
-                0
-            }
+            *result = l > imm as u64;
         }
         32 => {
             let l = E256::get(lhs);
             let r = E256::from(imm);
-            if l.cmp_u(&r).is_gt() {
-                1
-            } else {
-                0
-            }
+            *result = l.cmp_u(&r).is_gt();
         }
         _ => {
             panic!("Invalid sew");
         }
     };
-    set_bit_in_slice(result, index, res);
 }
-fn test_vmsgtu(sew: u64, lmul: i64, avl: u64, imm: i64) {
-    fn op(lhs: &[u8], imm: i64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vi(lhs, imm, result, sew, avl, lmul, |imm| unsafe {
+fn test_vmsgtu() {
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
             match imm {
                 -16 => {
                     rvv_asm!("vmsgtu.vi v24, v8, -16");
@@ -708,48 +631,31 @@ fn test_vmsgtu(sew: u64, lmul: i64, avl: u64, imm: i64) {
                     panic!("Invalid immediate: {}", imm);
                 }
             }
-        });
+        }
     }
-    run_vmsop_vi(
-        sew,
-        lmul,
-        avl,
-        imm,
-        expected_gtu,
-        op,
-        WideningCategory::None,
-        "vmsgtu.vi",
-    );
+    run_template_m_vi(expected_gtu, op, false, "vmsgtu.vi");
 }
 
-fn expected_gt(lhs: &[u8], imm: i64, result: &mut [u8], index: usize) {
-    let res = match lhs.len() {
+fn expected_gt(lhs: &[u8], imm: i64, result: &mut bool) {
+    match lhs.len() {
         8 => {
             let l = i64::from_le_bytes(lhs.try_into().unwrap());
-            if l > imm {
-                1
-            } else {
-                0
-            }
+            *result = l > imm;
         }
         32 => {
             let l = E256::get(lhs);
             let r = conver_to_i256(E128::from(imm as i128));
-            if l.cmp_s(&r).is_gt() {
-                1
-            } else {
-                0
-            }
+            *result = l.cmp_s(&r).is_gt();
         }
         _ => {
             panic!("Invalid sew");
         }
     };
-    set_bit_in_slice(result, index, res);
 }
-fn test_vmsgt(sew: u64, lmul: i64, avl: u64, imm: i64) {
-    fn op(lhs: &[u8], imm: i64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vi(lhs, imm, result, sew, avl, lmul, |imm| unsafe {
+fn test_vmsgt() {
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
             match imm {
                 -16 => {
                     rvv_asm!("vmsgt.vi v24, v8, -16");
@@ -851,36 +757,16 @@ fn test_vmsgt(sew: u64, lmul: i64, avl: u64, imm: i64) {
                     panic!("Invalid immediate: {}", imm);
                 }
             }
-        });
+        }
     }
-    run_vmsop_vi(
-        sew,
-        lmul,
-        avl,
-        imm,
-        expected_gt,
-        op,
-        WideningCategory::None,
-        "vmsgt.vi",
-    );
+    run_template_m_vi(expected_gt, op, false, "vmsgt.vi");
 }
 
 pub fn test_vmsop_vi() {
-    let mut imm = -16;
-    for sew in [64, 256] {
-        for lmul in [-8, -2, 1, 4, 8] {
-            for avl in avl_iterator(sew, 4) {
-                test_vmseq(sew, lmul, avl, imm);
-                test_vmsne(sew, lmul, avl, imm);
-                test_vmsleu(sew, lmul, avl, imm);
-                test_vmsle(sew, lmul, avl, imm);
-                test_vmsgtu(sew, lmul, avl, imm);
-                test_vmsgt(sew, lmul, avl, imm);
-                imm += 1;
-                if imm > 15 {
-                    imm = -16;
-                }
-            }
-        }
-    }
+    test_vmseq();
+    test_vmsne();
+    test_vmsleu();
+    test_vmsle();
+    test_vmsgtu();
+    test_vmsgt();
 }

--- a/cases/src/vmsop_vi_cases.rs
+++ b/cases/src/vmsop_vi_cases.rs
@@ -23,113 +23,315 @@ fn expected_eq(lhs: &[u8], imm: i64, result: &mut bool) {
     };
 }
 fn test_vmseq() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                -16 => {
-                    rvv_asm!("vmseq.vi v24, v8, -16");
-                }
-                -15 => {
-                    rvv_asm!("vmseq.vi v24, v8, -15");
-                }
-                -14 => {
-                    rvv_asm!("vmseq.vi v24, v8, -14");
-                }
-                -13 => {
-                    rvv_asm!("vmseq.vi v24, v8, -13");
-                }
-                -12 => {
-                    rvv_asm!("vmseq.vi v24, v8, -12");
-                }
-                -11 => {
-                    rvv_asm!("vmseq.vi v24, v8, -11");
-                }
-                -10 => {
-                    rvv_asm!("vmseq.vi v24, v8, -10");
-                }
-                -9 => {
-                    rvv_asm!("vmseq.vi v24, v8, -9");
-                }
-                -8 => {
-                    rvv_asm!("vmseq.vi v24, v8, -8");
-                }
-                -7 => {
-                    rvv_asm!("vmseq.vi v24, v8, -7");
-                }
-                -6 => {
-                    rvv_asm!("vmseq.vi v24, v8, -6");
-                }
-                -5 => {
-                    rvv_asm!("vmseq.vi v24, v8, -5");
-                }
-                -4 => {
-                    rvv_asm!("vmseq.vi v24, v8, -4");
-                }
-                -3 => {
-                    rvv_asm!("vmseq.vi v24, v8, -3");
-                }
-                -2 => {
-                    rvv_asm!("vmseq.vi v24, v8, -2");
-                }
-                -1 => {
-                    rvv_asm!("vmseq.vi v24, v8, -1");
-                }
-                0 => {
-                    rvv_asm!("vmseq.vi v24, v8, 0");
-                }
-                1 => {
-                    rvv_asm!("vmseq.vi v24, v8, 1");
-                }
-                2 => {
-                    rvv_asm!("vmseq.vi v24, v8, 2");
-                }
-                3 => {
-                    rvv_asm!("vmseq.vi v24, v8, 3");
-                }
-                4 => {
-                    rvv_asm!("vmseq.vi v24, v8, 4");
-                }
-                5 => {
-                    rvv_asm!("vmseq.vi v24, v8, 5");
-                }
-                6 => {
-                    rvv_asm!("vmseq.vi v24, v8, 6");
-                }
-                7 => {
-                    rvv_asm!("vmseq.vi v24, v8, 7");
-                }
-                8 => {
-                    rvv_asm!("vmseq.vi v24, v8, 8");
-                }
-                9 => {
-                    rvv_asm!("vmseq.vi v24, v8, 9");
-                }
-                10 => {
-                    rvv_asm!("vmseq.vi v24, v8, 10");
-                }
-                11 => {
-                    rvv_asm!("vmseq.vi v24, v8, 11");
-                }
-                12 => {
-                    rvv_asm!("vmseq.vi v24, v8, 12");
-                }
-                13 => {
-                    rvv_asm!("vmseq.vi v24, v8, 13");
-                }
-                14 => {
-                    rvv_asm!("vmseq.vi v24, v8, 14");
-                }
-                15 => {
-                    rvv_asm!("vmseq.vi v24, v8, 15");
-                }
+                -16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, -1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, -1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmseq.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmseq.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("Invalid immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
-    run_template_m_vi(expected_eq, op, false, "vmseq.vi");
+
+    run_template_m_vi(expected_eq, op, true, "vmseq.vi");
 }
 
 fn expected_ne(lhs: &[u8], imm: i64, result: &mut bool) {
@@ -149,113 +351,315 @@ fn expected_ne(lhs: &[u8], imm: i64, result: &mut bool) {
     };
 }
 fn test_vmsne() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                -16 => {
-                    rvv_asm!("vmsne.vi v24, v8, -16");
-                }
-                -15 => {
-                    rvv_asm!("vmsne.vi v24, v8, -15");
-                }
-                -14 => {
-                    rvv_asm!("vmsne.vi v24, v8, -14");
-                }
-                -13 => {
-                    rvv_asm!("vmsne.vi v24, v8, -13");
-                }
-                -12 => {
-                    rvv_asm!("vmsne.vi v24, v8, -12");
-                }
-                -11 => {
-                    rvv_asm!("vmsne.vi v24, v8, -11");
-                }
-                -10 => {
-                    rvv_asm!("vmsne.vi v24, v8, -10");
-                }
-                -9 => {
-                    rvv_asm!("vmsne.vi v24, v8, -9");
-                }
-                -8 => {
-                    rvv_asm!("vmsne.vi v24, v8, -8");
-                }
-                -7 => {
-                    rvv_asm!("vmsne.vi v24, v8, -7");
-                }
-                -6 => {
-                    rvv_asm!("vmsne.vi v24, v8, -6");
-                }
-                -5 => {
-                    rvv_asm!("vmsne.vi v24, v8, -5");
-                }
-                -4 => {
-                    rvv_asm!("vmsne.vi v24, v8, -4");
-                }
-                -3 => {
-                    rvv_asm!("vmsne.vi v24, v8, -3");
-                }
-                -2 => {
-                    rvv_asm!("vmsne.vi v24, v8, -2");
-                }
-                -1 => {
-                    rvv_asm!("vmsne.vi v24, v8, -1");
-                }
-                0 => {
-                    rvv_asm!("vmsne.vi v24, v8, 0");
-                }
-                1 => {
-                    rvv_asm!("vmsne.vi v24, v8, 1");
-                }
-                2 => {
-                    rvv_asm!("vmsne.vi v24, v8, 2");
-                }
-                3 => {
-                    rvv_asm!("vmsne.vi v24, v8, 3");
-                }
-                4 => {
-                    rvv_asm!("vmsne.vi v24, v8, 4");
-                }
-                5 => {
-                    rvv_asm!("vmsne.vi v24, v8, 5");
-                }
-                6 => {
-                    rvv_asm!("vmsne.vi v24, v8, 6");
-                }
-                7 => {
-                    rvv_asm!("vmsne.vi v24, v8, 7");
-                }
-                8 => {
-                    rvv_asm!("vmsne.vi v24, v8, 8");
-                }
-                9 => {
-                    rvv_asm!("vmsne.vi v24, v8, 9");
-                }
-                10 => {
-                    rvv_asm!("vmsne.vi v24, v8, 10");
-                }
-                11 => {
-                    rvv_asm!("vmsne.vi v24, v8, 11");
-                }
-                12 => {
-                    rvv_asm!("vmsne.vi v24, v8, 12");
-                }
-                13 => {
-                    rvv_asm!("vmsne.vi v24, v8, 13");
-                }
-                14 => {
-                    rvv_asm!("vmsne.vi v24, v8, 14");
-                }
-                15 => {
-                    rvv_asm!("vmsne.vi v24, v8, 15");
-                }
+                -16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, -1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, -1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsne.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsne.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("Invalid immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
-    run_template_m_vi(expected_ne, op, false, "vmsne.vi");
+
+    run_template_m_vi(expected_ne, op, true, "vmsne.vi");
 }
 
 fn expected_leu(lhs: &[u8], imm: i64, result: &mut bool) {
@@ -275,113 +679,315 @@ fn expected_leu(lhs: &[u8], imm: i64, result: &mut bool) {
     };
 }
 fn test_vmsleu() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                -16 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -16");
-                }
-                -15 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -15");
-                }
-                -14 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -14");
-                }
-                -13 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -13");
-                }
-                -12 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -12");
-                }
-                -11 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -11");
-                }
-                -10 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -10");
-                }
-                -9 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -9");
-                }
-                -8 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -8");
-                }
-                -7 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -7");
-                }
-                -6 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -6");
-                }
-                -5 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -5");
-                }
-                -4 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -4");
-                }
-                -3 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -3");
-                }
-                -2 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -2");
-                }
-                -1 => {
-                    rvv_asm!("vmsleu.vi v24, v8, -1");
-                }
-                0 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 0");
-                }
-                1 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 1");
-                }
-                2 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 2");
-                }
-                3 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 3");
-                }
-                4 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 4");
-                }
-                5 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 5");
-                }
-                6 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 6");
-                }
-                7 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 7");
-                }
-                8 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 8");
-                }
-                9 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 9");
-                }
-                10 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 10");
-                }
-                11 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 11");
-                }
-                12 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 12");
-                }
-                13 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 13");
-                }
-                14 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 14");
-                }
-                15 => {
-                    rvv_asm!("vmsleu.vi v24, v8, 15");
-                }
+                -16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, -1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsleu.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("Invalid immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
-    run_template_m_vi(expected_leu, op, false, "vmsleu.vi");
+
+    run_template_m_vi(expected_leu, op, true, "vmsleu.vi");
 }
 
 fn expected_le(lhs: &[u8], imm: i64, result: &mut bool) {
@@ -401,113 +1007,315 @@ fn expected_le(lhs: &[u8], imm: i64, result: &mut bool) {
     };
 }
 fn test_vmsle() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                -16 => {
-                    rvv_asm!("vmsle.vi v24, v8, -16");
-                }
-                -15 => {
-                    rvv_asm!("vmsle.vi v24, v8, -15");
-                }
-                -14 => {
-                    rvv_asm!("vmsle.vi v24, v8, -14");
-                }
-                -13 => {
-                    rvv_asm!("vmsle.vi v24, v8, -13");
-                }
-                -12 => {
-                    rvv_asm!("vmsle.vi v24, v8, -12");
-                }
-                -11 => {
-                    rvv_asm!("vmsle.vi v24, v8, -11");
-                }
-                -10 => {
-                    rvv_asm!("vmsle.vi v24, v8, -10");
-                }
-                -9 => {
-                    rvv_asm!("vmsle.vi v24, v8, -9");
-                }
-                -8 => {
-                    rvv_asm!("vmsle.vi v24, v8, -8");
-                }
-                -7 => {
-                    rvv_asm!("vmsle.vi v24, v8, -7");
-                }
-                -6 => {
-                    rvv_asm!("vmsle.vi v24, v8, -6");
-                }
-                -5 => {
-                    rvv_asm!("vmsle.vi v24, v8, -5");
-                }
-                -4 => {
-                    rvv_asm!("vmsle.vi v24, v8, -4");
-                }
-                -3 => {
-                    rvv_asm!("vmsle.vi v24, v8, -3");
-                }
-                -2 => {
-                    rvv_asm!("vmsle.vi v24, v8, -2");
-                }
-                -1 => {
-                    rvv_asm!("vmsle.vi v24, v8, -1");
-                }
-                0 => {
-                    rvv_asm!("vmsle.vi v24, v8, 0");
-                }
-                1 => {
-                    rvv_asm!("vmsle.vi v24, v8, 1");
-                }
-                2 => {
-                    rvv_asm!("vmsle.vi v24, v8, 2");
-                }
-                3 => {
-                    rvv_asm!("vmsle.vi v24, v8, 3");
-                }
-                4 => {
-                    rvv_asm!("vmsle.vi v24, v8, 4");
-                }
-                5 => {
-                    rvv_asm!("vmsle.vi v24, v8, 5");
-                }
-                6 => {
-                    rvv_asm!("vmsle.vi v24, v8, 6");
-                }
-                7 => {
-                    rvv_asm!("vmsle.vi v24, v8, 7");
-                }
-                8 => {
-                    rvv_asm!("vmsle.vi v24, v8, 8");
-                }
-                9 => {
-                    rvv_asm!("vmsle.vi v24, v8, 9");
-                }
-                10 => {
-                    rvv_asm!("vmsle.vi v24, v8, 10");
-                }
-                11 => {
-                    rvv_asm!("vmsle.vi v24, v8, 11");
-                }
-                12 => {
-                    rvv_asm!("vmsle.vi v24, v8, 12");
-                }
-                13 => {
-                    rvv_asm!("vmsle.vi v24, v8, 13");
-                }
-                14 => {
-                    rvv_asm!("vmsle.vi v24, v8, 14");
-                }
-                15 => {
-                    rvv_asm!("vmsle.vi v24, v8, 15");
-                }
+                -16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, -1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, -1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsle.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsle.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("Invalid immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
-    run_template_m_vi(expected_le, op, false, "vmsle.vi");
+
+    run_template_m_vi(expected_le, op, true, "vmsle.vi");
 }
 
 fn expected_gtu(lhs: &[u8], imm: i64, result: &mut bool) {
@@ -527,113 +1335,315 @@ fn expected_gtu(lhs: &[u8], imm: i64, result: &mut bool) {
     };
 }
 fn test_vmsgtu() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                -16 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -16");
-                }
-                -15 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -15");
-                }
-                -14 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -14");
-                }
-                -13 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -13");
-                }
-                -12 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -12");
-                }
-                -11 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -11");
-                }
-                -10 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -10");
-                }
-                -9 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -9");
-                }
-                -8 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -8");
-                }
-                -7 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -7");
-                }
-                -6 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -6");
-                }
-                -5 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -5");
-                }
-                -4 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -4");
-                }
-                -3 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -3");
-                }
-                -2 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -2");
-                }
-                -1 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, -1");
-                }
-                0 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 0");
-                }
-                1 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 1");
-                }
-                2 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 2");
-                }
-                3 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 3");
-                }
-                4 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 4");
-                }
-                5 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 5");
-                }
-                6 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 6");
-                }
-                7 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 7");
-                }
-                8 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 8");
-                }
-                9 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 9");
-                }
-                10 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 10");
-                }
-                11 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 11");
-                }
-                12 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 12");
-                }
-                13 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 13");
-                }
-                14 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 14");
-                }
-                15 => {
-                    rvv_asm!("vmsgtu.vi v24, v8, 15");
-                }
+                -16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, -1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgtu.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("Invalid immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
-    run_template_m_vi(expected_gtu, op, false, "vmsgtu.vi");
+
+    run_template_m_vi(expected_gtu, op, true, "vmsgtu.vi");
 }
 
 fn expected_gt(lhs: &[u8], imm: i64, result: &mut bool) {
@@ -653,112 +1663,314 @@ fn expected_gt(lhs: &[u8], imm: i64, result: &mut bool) {
     };
 }
 fn test_vmsgt() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                -16 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -16");
-                }
-                -15 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -15");
-                }
-                -14 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -14");
-                }
-                -13 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -13");
-                }
-                -12 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -12");
-                }
-                -11 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -11");
-                }
-                -10 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -10");
-                }
-                -9 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -9");
-                }
-                -8 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -8");
-                }
-                -7 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -7");
-                }
-                -6 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -6");
-                }
-                -5 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -5");
-                }
-                -4 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -4");
-                }
-                -3 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -3");
-                }
-                -2 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -2");
-                }
-                -1 => {
-                    rvv_asm!("vmsgt.vi v24, v8, -1");
-                }
-                0 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 0");
-                }
-                1 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 1");
-                }
-                2 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 2");
-                }
-                3 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 3");
-                }
-                4 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 4");
-                }
-                5 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 5");
-                }
-                6 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 6");
-                }
-                7 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 7");
-                }
-                8 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 8");
-                }
-                9 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 9");
-                }
-                10 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 10");
-                }
-                11 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 11");
-                }
-                12 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 12");
-                }
-                13 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 13");
-                }
-                14 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 14");
-                }
-                15 => {
-                    rvv_asm!("vmsgt.vi v24, v8, 15");
-                }
+                -16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, -1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vmsgt.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("Invalid immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
+
     run_template_m_vi(expected_gt, op, false, "vmsgt.vi");
 }
 

--- a/cases/src/vmsop_vv_cases.rs
+++ b/cases/src/vmsop_vv_cases.rs
@@ -1,252 +1,224 @@
 use core::{arch::asm, convert::TryInto};
 use eint::{Eint, E256};
 use rvv_asm::rvv_asm;
-use rvv_testcases::{
-    intrinsic::vmsop_vv,
-    misc::{avl_iterator, set_bit_in_slice},
-    runner::{run_vmsop_vv, WideningCategory},
-};
+use rvv_testcases::runner::{run_template_m_vv, MaskType};
 
-fn expected_eq(lhs: &[u8], rhs: &[u8], result: &mut [u8], index: usize) {
+fn expected_eq(lhs: &[u8], rhs: &[u8], result: &mut bool) {
     assert_eq!(lhs.len(), rhs.len());
     match lhs.len() {
         8 => {
             let l = u64::from_le_bytes(lhs.try_into().unwrap());
             let r = u64::from_le_bytes(rhs.try_into().unwrap());
-            let res = if l == r { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l == r;
         }
         32 => {
             let l = E256::get(lhs);
             let r = E256::get(rhs);
-            let res = if l == r { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l == r;
         }
         _ => {
             panic!("Invalid sew");
         }
     }
 }
-fn test_vmseq(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vmseq.vv v24, v8, v16");
-        });
+fn test_vmseq() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vmseq.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vmseq.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vmsop_vv(
-        sew,
-        lmul,
-        avl,
-        expected_eq,
-        op,
-        WideningCategory::None,
-        "vmseq.vv",
-    );
+    run_template_m_vv(expected_eq, op, true, "vmseq.vv");
 }
 
-fn expected_ne(lhs: &[u8], rhs: &[u8], result: &mut [u8], index: usize) {
+fn expected_ne(lhs: &[u8], rhs: &[u8], result: &mut bool) {
     assert_eq!(lhs.len(), rhs.len());
     match lhs.len() {
         8 => {
             let l = u64::from_le_bytes(lhs.try_into().unwrap());
             let r = u64::from_le_bytes(rhs.try_into().unwrap());
-            let res = if l != r { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l != r;
         }
         32 => {
             let l = E256::get(lhs);
             let r = E256::get(rhs);
-            let res = if l != r { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l != r;
         }
         _ => {
             panic!("Invalid sew");
         }
     }
 }
-fn test_vmsne(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vmsne.vv v24, v8, v16");
-        });
+fn test_vmsne() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vmsne.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vmsne.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vmsop_vv(
-        sew,
-        lmul,
-        avl,
-        expected_ne,
-        op,
-        WideningCategory::None,
-        "vmsne.vv",
-    );
+    run_template_m_vv(expected_ne, op, true, "vmsne.vv");
 }
 
-fn expected_ltu(lhs: &[u8], rhs: &[u8], result: &mut [u8], index: usize) {
+fn expected_ltu(lhs: &[u8], rhs: &[u8], result: &mut bool) {
     assert_eq!(lhs.len(), rhs.len());
     match lhs.len() {
         8 => {
             let l = u64::from_le_bytes(lhs.try_into().unwrap());
             let r = u64::from_le_bytes(rhs.try_into().unwrap());
-            let res = if l < r { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l < r;
         }
         32 => {
             let l = E256::get(lhs);
             let r = E256::get(rhs);
-            let res = if l < r { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l < r;
         }
         _ => {
             panic!("Invalid sew");
         }
     }
 }
-fn test_vmsltu(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vmsltu.vv v24, v8, v16");
-        });
+fn test_vmsltu() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vmsltu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vmsltu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vmsop_vv(
-        sew,
-        lmul,
-        avl,
-        expected_ltu,
-        op,
-        WideningCategory::None,
-        "vmsltu.vv",
-    );
+    run_template_m_vv(expected_ltu, op, true, "vmsltu.vv");
 }
 
-fn expected_lt(lhs: &[u8], rhs: &[u8], result: &mut [u8], index: usize) {
+fn expected_lt(lhs: &[u8], rhs: &[u8], result: &mut bool) {
     assert_eq!(lhs.len(), rhs.len());
     match lhs.len() {
         8 => {
             let l = i64::from_le_bytes(lhs.try_into().unwrap());
             let r = i64::from_le_bytes(rhs.try_into().unwrap());
-            let res = if l < r { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l < r;
         }
         32 => {
             let l = E256::get(lhs);
             let r = E256::get(rhs);
-            let res = if l.cmp_s(&r).is_le() { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l.cmp_s(&r).is_le();
         }
         _ => {
             panic!("Invalid sew");
         }
     }
 }
-fn test_vmslt(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vmslt.vv v24, v8, v16");
-        });
+fn test_vmslt() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vmslt.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vmslt.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vmsop_vv(
-        sew,
-        lmul,
-        avl,
-        expected_lt,
-        op,
-        WideningCategory::None,
-        "vmslt.vv",
-    );
+    run_template_m_vv(expected_lt, op, true, "vmslt.vv");
 }
 
-fn expected_leu(lhs: &[u8], rhs: &[u8], result: &mut [u8], index: usize) {
+fn expected_leu(lhs: &[u8], rhs: &[u8], result: &mut bool) {
     assert_eq!(lhs.len(), rhs.len());
     match lhs.len() {
         8 => {
             let l = u64::from_le_bytes(lhs.try_into().unwrap());
             let r = u64::from_le_bytes(rhs.try_into().unwrap());
-            let res = if l <= r { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l <= r;
         }
         32 => {
             let l = E256::get(lhs);
             let r = E256::get(rhs);
-            let res = if l <= r { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l <= r;
         }
         _ => {
             panic!("Invalid sew");
         }
     }
 }
-fn test_vmsleu(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vmsleu.vv v24, v8, v16");
-        });
+fn test_vmsleu() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vmsleu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vmsleu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vmsop_vv(
-        sew,
-        lmul,
-        avl,
-        expected_leu,
-        op,
-        WideningCategory::None,
-        "vmsleu.vv",
-    );
+    run_template_m_vv(expected_leu, op, true, "vmsleu.vv");
 }
 
-fn expected_le(lhs: &[u8], rhs: &[u8], result: &mut [u8], index: usize) {
+fn expected_le(lhs: &[u8], rhs: &[u8], result: &mut bool) {
     assert_eq!(lhs.len(), rhs.len());
     match lhs.len() {
         8 => {
             let l = i64::from_le_bytes(lhs.try_into().unwrap());
             let r = i64::from_le_bytes(rhs.try_into().unwrap());
-            let res = if l <= r { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l <= r;
         }
         32 => {
             let l = E256::get(lhs);
             let r = E256::get(rhs);
             let ord = l.cmp_s(&r);
-            let res = if ord.is_eq() || ord.is_le() { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = ord.is_eq() || ord.is_le();
         }
         _ => {
             panic!("Invalid sew");
         }
     }
 }
-fn test_vmsle(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vmsle.vv v24, v8, v16");
-        });
-    }
-
-    run_vmsop_vv(
-        sew,
-        lmul,
-        avl,
-        expected_le,
-        op,
-        WideningCategory::None,
-        "vmsle.vv",
-    );
-}
-
-pub fn test_vmsop_vv() {
-    for sew in [64, 256] {
-        for lmul in [-8, -2, 1, 4, 8] {
-            for avl in avl_iterator(sew, 4) {
-                test_vmseq(sew, lmul, avl);
-                test_vmsne(sew, lmul, avl);
-                test_vmsltu(sew, lmul, avl);
-                test_vmslt(sew, lmul, avl);
-                test_vmsleu(sew, lmul, avl);
-                test_vmsle(sew, lmul, avl);
+fn test_vmsle() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vmsle.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vmsle.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
             }
         }
     }
+    run_template_m_vv(expected_le, op, true, "vmsle.vv");
+}
+
+pub fn test_vmsop_vv() {
+    test_vmseq();
+    test_vmsne();
+    test_vmsltu();
+    test_vmslt();
+    test_vmsleu();
+    test_vmsle();
 }

--- a/cases/src/vmsop_vx_cases.rs
+++ b/cases/src/vmsop_vx_cases.rs
@@ -1,307 +1,288 @@
 use core::{arch::asm, convert::TryInto};
 use eint::{Eint, E256};
 use rvv_asm::rvv_asm;
-use rvv_testcases::{
-    intrinsic::vmsop_vx,
-    misc::{avl_iterator, set_bit_in_slice},
-    runner::{run_vmsop_vx, WideningCategory},
-};
+use rvv_testcases::runner::{run_template_m_vx, MaskType};
 
-fn expected_op_eq(lhs: &[u8], x: u64, result: &mut [u8], index: usize) {
+fn expected_op_eq(lhs: &[u8], x: u64, result: &mut bool) {
     match lhs.len() {
         8 => {
             let l = i64::from_le_bytes(lhs.try_into().unwrap());
-            let res = if l == x as i64 { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l == x as i64;
         }
         32 => {
             let l = E256::get(lhs);
             let r = E256::from(x as i64);
-            let res = if l.cmp_s(&r).is_eq() { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l.cmp_s(&r).is_eq();
         }
         _ => {
             panic!("Invalid sew");
         }
     }
 }
-fn test_vmseq(sew: u64, lmul: i64, avl: u64) {
-    fn eq(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vx(lhs, x, result, sew, avl, lmul, |x| unsafe {
-            rvv_asm!("mv t0, {}", "vmseq.vx v24, v8, t0", in (reg) x);
-        });
+fn test_vmseq() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmseq.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmseq.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vmsop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_eq,
-        eq,
-        WideningCategory::None,
-        "vmseq.vx",
-    );
+    run_template_m_vx(expected_op_eq, op, true, "vmseq.vx");
 }
 
-fn expected_op_ne(lhs: &[u8], x: u64, result: &mut [u8], index: usize) {
+fn expected_op_ne(lhs: &[u8], x: u64, result: &mut bool) {
     match lhs.len() {
         8 => {
             let l = i64::from_le_bytes(lhs.try_into().unwrap());
-            let res = if l != x as i64 { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l != x as i64;
         }
         32 => {
             let l = E256::get(lhs);
             let r = E256::from(x as i64);
-            let res = if l.cmp_s(&r).is_ne() { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l.cmp_s(&r).is_ne();
         }
         _ => {
             panic!("Invalid sew");
         }
     }
 }
-fn test_vmsne(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vx(lhs, x, result, sew, avl, lmul, |x| unsafe {
-            rvv_asm!("mv t0, {}", "vmsne.vx v24, v8, t0", in (reg) x);
-        });
+fn test_vmsne() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmsne.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmsne.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vmsop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_ne,
-        op,
-        WideningCategory::None,
-        "vmsne.vx",
-    );
+    run_template_m_vx(expected_op_ne, op, true, "vmsne.vx");
 }
 
-fn expected_op_ltu(lhs: &[u8], x: u64, result: &mut [u8], index: usize) {
+fn expected_op_ltu(lhs: &[u8], x: u64, result: &mut bool) {
     match lhs.len() {
         8 => {
             let l = u64::from_le_bytes(lhs.try_into().unwrap());
-            let res = if l < x { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l < x;
         }
         32 => {
             let l = E256::get(lhs);
             let r = E256::from(x as i64);
-            let res = if l.cmp_u(&r).is_lt() { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l.cmp_u(&r).is_lt();
         }
         _ => {
             panic!("Invalid sew");
         }
     }
 }
-fn test_vmsltu(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vx(lhs, x, result, sew, avl, lmul, |x| unsafe {
-            rvv_asm!("mv t0, {}", "vmsltu.vx v24, v8, t0", in (reg) x);
-        });
+fn test_vmsltu() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmsltu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmsltu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vmsop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_ltu,
-        op,
-        WideningCategory::None,
-        "vmsltu.vx",
-    );
+    run_template_m_vx(expected_op_ltu, op, true, "vmsltu.vx");
 }
 
-fn expected_op_lt(lhs: &[u8], x: u64, result: &mut [u8], index: usize) {
+fn expected_op_lt(lhs: &[u8], x: u64, result: &mut bool) {
     match lhs.len() {
         8 => {
             let l = i64::from_le_bytes(lhs.try_into().unwrap());
             let r = x as i64;
-            let res = if l < r { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l < r;
         }
         32 => {
             let l = E256::get(lhs);
             let r = E256::from(x as i64);
-            let res = if l.cmp_s(&r).is_lt() { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
+            *result = l.cmp_s(&r).is_lt();
         }
         _ => {
             panic!("Invalid sew");
         }
     }
 }
-fn test_vmslt(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vx(lhs, x, result, sew, avl, lmul, |x| unsafe {
-            rvv_asm!("mv t0, {}", "vmslt.vx v24, v8, t0", in (reg) x);
-        });
-    }
-    run_vmsop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_lt,
-        op,
-        WideningCategory::None,
-        "vmslt.vx",
-    );
-}
-
-fn expected_op_leu(lhs: &[u8], x: u64, result: &mut [u8], index: usize) {
-    match lhs.len() {
-        8 => {
-            let l = u64::from_le_bytes(lhs.try_into().unwrap());
-            let res = if l <= x { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
-        }
-        32 => {
-            let l = E256::get(lhs);
-            let r = E256::from(x as i64);
-            let res = if l.cmp_u(&r).is_le() { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
-        }
-        _ => {
-            panic!("Invalid sew");
-        }
-    }
-}
-fn test_vmsleu(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vx(lhs, x, result, sew, avl, lmul, |x| unsafe {
-            rvv_asm!("mv t0, {}", "vmsleu.vx v24, v8, t0", in (reg) x);
-        });
-    }
-    run_vmsop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_leu,
-        op,
-        WideningCategory::None,
-        "vmsleu.vx",
-    );
-}
-
-fn expected_op_le(lhs: &[u8], x: u64, result: &mut [u8], index: usize) {
-    match lhs.len() {
-        8 => {
-            let l = i64::from_le_bytes(lhs.try_into().unwrap());
-            let res = if l <= x as i64 { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
-        }
-        32 => {
-            let l = E256::get(lhs);
-            let r = E256::from(x as i64);
-            let res = if l.cmp_s(&r).is_le() { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
-        }
-        _ => {
-            panic!("Invalid sew");
-        }
-    }
-}
-fn test_vmsle(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vx(lhs, x, result, sew, avl, lmul, |x| unsafe {
-            rvv_asm!("mv t0, {}", "vmsle.vx v24, v8, t0", in (reg) x);
-        });
-    }
-    run_vmsop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_le,
-        op,
-        WideningCategory::None,
-        "vmsle.vx",
-    );
-}
-
-fn expected_op_gtu(lhs: &[u8], x: u64, result: &mut [u8], index: usize) {
-    match lhs.len() {
-        8 => {
-            let l = u64::from_le_bytes(lhs.try_into().unwrap());
-            let res = if l > x { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
-        }
-        32 => {
-            let l = E256::get(lhs);
-            let r = E256::from(x as i64);
-            let res = if l.cmp_u(&r).is_gt() { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
-        }
-        _ => {
-            panic!("Invalid sew");
-        }
-    }
-}
-fn test_vmsgtu(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vx(lhs, x, result, sew, avl, lmul, |x| unsafe {
-            rvv_asm!("mv t0, {}", "vmsgtu.vx v24, v8, t0", in (reg) x);
-        });
-    }
-    run_vmsop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_gtu,
-        op,
-        WideningCategory::None,
-        "vmsgtu.vx",
-    );
-}
-
-fn expected_op_gt(lhs: &[u8], x: u64, result: &mut [u8], index: usize) {
-    match lhs.len() {
-        8 => {
-            let l = i64::from_le_bytes(lhs.try_into().unwrap());
-            let res = if l > x as i64 { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
-        }
-        32 => {
-            let l = E256::get(lhs);
-            let r = E256::from(x as i64);
-            let res = if l.cmp_s(&r).is_gt() { 1 } else { 0 };
-            set_bit_in_slice(result, index, res);
-        }
-        _ => {
-            panic!("Invalid sew");
-        }
-    }
-}
-fn test_vmsgt(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vmsop_vx(lhs, x, result, sew, avl, lmul, |x| unsafe {
-            rvv_asm!("mv t0, {}", "vmsgt.vx v24, v8, t0", in (reg) x);
-        });
-    }
-    run_vmsop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_gt,
-        op,
-        WideningCategory::None,
-        "vmsgt.vx",
-    );
-}
-
-pub fn test_vmsop_vx() {
-    for sew in [64, 256] {
-        for lmul in [-8, -2, 1, 4, 8] {
-            for avl in avl_iterator(sew, 4) {
-                test_vmseq(sew, lmul, avl);
-                test_vmsne(sew, lmul, avl);
-                test_vmsltu(sew, lmul, avl);
-                test_vmslt(sew, lmul, avl);
-                test_vmsleu(sew, lmul, avl);
-                test_vmsle(sew, lmul, avl);
-                test_vmsgtu(sew, lmul, avl);
-                test_vmsgt(sew, lmul, avl);
+fn test_vmslt() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmslt.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmslt.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
             }
         }
     }
+    run_template_m_vx(expected_op_lt, op, true, "vmslt.vx");
+}
+
+fn expected_op_leu(lhs: &[u8], x: u64, result: &mut bool) {
+    match lhs.len() {
+        8 => {
+            let l = u64::from_le_bytes(lhs.try_into().unwrap());
+            *result = l <= x;
+        }
+        32 => {
+            let l = E256::get(lhs);
+            let r = E256::from(x as i64);
+            *result = l.cmp_u(&r).is_le();
+        }
+        _ => {
+            panic!("Invalid sew");
+        }
+    }
+}
+fn test_vmsleu() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmsleu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmsleu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
+    }
+    run_template_m_vx(expected_op_leu, op, true, "vmsleu.vx");
+}
+
+fn expected_op_le(lhs: &[u8], x: u64, result: &mut bool) {
+    match lhs.len() {
+        8 => {
+            let l = i64::from_le_bytes(lhs.try_into().unwrap());
+            *result = l <= x as i64;
+        }
+        32 => {
+            let l = E256::get(lhs);
+            let r = E256::from(x as i64);
+            *result = l.cmp_s(&r).is_le();
+        }
+        _ => {
+            panic!("Invalid sew");
+        }
+    }
+}
+fn test_vmsle() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmsle.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmsle.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
+    }
+    run_template_m_vx(expected_op_le, op, true, "vmsle.vx");
+}
+
+fn expected_op_gtu(lhs: &[u8], x: u64, result: &mut bool) {
+    match lhs.len() {
+        8 => {
+            let l = u64::from_le_bytes(lhs.try_into().unwrap());
+            *result = l > x;
+        }
+        32 => {
+            let l = E256::get(lhs);
+            let r = E256::from(x as i64);
+            *result = l.cmp_u(&r).is_gt();
+        }
+        _ => {
+            panic!("Invalid sew");
+        }
+    }
+}
+fn test_vmsgtu() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmsgtu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmsgtu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
+    }
+    run_template_m_vx(expected_op_gtu, op, true, "vmsgtu.vx");
+}
+
+fn expected_op_gt(lhs: &[u8], x: u64, result: &mut bool) {
+    match lhs.len() {
+        8 => {
+            let l = i64::from_le_bytes(lhs.try_into().unwrap());
+            *result = l > x as i64;
+        }
+        32 => {
+            let l = E256::get(lhs);
+            let r = E256::from(x as i64);
+            *result = l.cmp_s(&r).is_gt();
+        }
+        _ => {
+            panic!("Invalid sew");
+        }
+    }
+}
+fn test_vmsgt() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmsgt.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmsgt.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
+    }
+    run_template_m_vx(expected_op_gt, op, true, "vmsgt.vx");
+}
+
+pub fn test_vmsop_vx() {
+    test_vmseq();
+    test_vmsne();
+    test_vmsltu();
+    test_vmslt();
+    test_vmsleu();
+    test_vmsle();
+    test_vmsgtu();
+    test_vmsgt();
 }

--- a/cases/src/vop_vi_cases.rs
+++ b/cases/src/vop_vi_cases.rs
@@ -47,113 +47,314 @@ fn expected_op_add(lhs: &[u8], imm: i64, result: &mut [u8]) {
 }
 fn test_vadd_vi() {
     // test combinations of lmul, sew, avl, etc
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                15 => {
-                    rvv_asm!("vadd.vi v24, v8, 15");
-                }
-                14 => {
-                    rvv_asm!("vadd.vi v24, v8, 14");
-                }
-                13 => {
-                    rvv_asm!("vadd.vi v24, v8, 13");
-                }
-                12 => {
-                    rvv_asm!("vadd.vi v24, v8, 12");
-                }
-                11 => {
-                    rvv_asm!("vadd.vi v24, v8, 11");
-                }
-                10 => {
-                    rvv_asm!("vadd.vi v24, v8, 10");
-                }
-                9 => {
-                    rvv_asm!("vadd.vi v24, v8, 9");
-                }
-                8 => {
-                    rvv_asm!("vadd.vi v24, v8, 8");
-                }
-                7 => {
-                    rvv_asm!("vadd.vi v24, v8, 7");
-                }
-                6 => {
-                    rvv_asm!("vadd.vi v24, v8, 6");
-                }
-                5 => {
-                    rvv_asm!("vadd.vi v24, v8, 5");
-                }
-                4 => {
-                    rvv_asm!("vadd.vi v24, v8, 4");
-                }
-                3 => {
-                    rvv_asm!("vadd.vi v24, v8, 3");
-                }
-                2 => {
-                    rvv_asm!("vadd.vi v24, v8, 2");
-                }
-                1 => {
-                    rvv_asm!("vadd.vi v24, v8, 1");
-                }
-                0 => {
-                    rvv_asm!("vadd.vi v24, v8, 0");
-                }
-                -1 => {
-                    rvv_asm!("vadd.vi v24, v8, -1");
-                }
-                -2 => {
-                    rvv_asm!("vadd.vi v24, v8, -2");
-                }
-                -3 => {
-                    rvv_asm!("vadd.vi v24, v8, -3");
-                }
-                -4 => {
-                    rvv_asm!("vadd.vi v24, v8, -4");
-                }
-                -5 => {
-                    rvv_asm!("vadd.vi v24, v8, -5");
-                }
-                -6 => {
-                    rvv_asm!("vadd.vi v24, v8, -6");
-                }
-                -7 => {
-                    rvv_asm!("vadd.vi v24, v8, -7");
-                }
-                -8 => {
-                    rvv_asm!("vadd.vi v24, v8, -8");
-                }
-                -9 => {
-                    rvv_asm!("vadd.vi v24, v8, -9");
-                }
-                -10 => {
-                    rvv_asm!("vadd.vi v24, v8, -10");
-                }
-                -11 => {
-                    rvv_asm!("vadd.vi v24, v8, -11");
-                }
-                -12 => {
-                    rvv_asm!("vadd.vi v24, v8, -12");
-                }
-                -13 => {
-                    rvv_asm!("vadd.vi v24, v8, -13");
-                }
-                -14 => {
-                    rvv_asm!("vadd.vi v24, v8, -14");
-                }
-                -15 => {
-                    rvv_asm!("vadd.vi v24, v8, -15");
-                }
-                -16 => {
-                    rvv_asm!("vadd.vi v24, v8, -16");
-                }
+                -16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, -1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, -1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vadd.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vadd.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("can't support this immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
-    run_template_v_vi(expected_op_add, op, true, "vadd.vi");
+    run_template_v_vi(expected_op_add, op, true, true, "vadd.vi");
 }
 
 fn expected_op_sub(lhs: &[u8], imm: i64, result: &mut [u8]) {
@@ -201,114 +402,315 @@ fn expected_op_sub(lhs: &[u8], imm: i64, result: &mut [u8]) {
     }
 }
 fn test_vrsub_vi() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                15 => {
-                    rvv_asm!("vrsub.vi v24, v8, 15");
-                }
-                14 => {
-                    rvv_asm!("vrsub.vi v24, v8, 14");
-                }
-                13 => {
-                    rvv_asm!("vrsub.vi v24, v8, 13");
-                }
-                12 => {
-                    rvv_asm!("vrsub.vi v24, v8, 12");
-                }
-                11 => {
-                    rvv_asm!("vrsub.vi v24, v8, 11");
-                }
-                10 => {
-                    rvv_asm!("vrsub.vi v24, v8, 10");
-                }
-                9 => {
-                    rvv_asm!("vrsub.vi v24, v8, 9");
-                }
-                8 => {
-                    rvv_asm!("vrsub.vi v24, v8, 8");
-                }
-                7 => {
-                    rvv_asm!("vrsub.vi v24, v8, 7");
-                }
-                6 => {
-                    rvv_asm!("vrsub.vi v24, v8, 6");
-                }
-                5 => {
-                    rvv_asm!("vrsub.vi v24, v8, 5");
-                }
-                4 => {
-                    rvv_asm!("vrsub.vi v24, v8, 4");
-                }
-                3 => {
-                    rvv_asm!("vrsub.vi v24, v8, 3");
-                }
-                2 => {
-                    rvv_asm!("vrsub.vi v24, v8, 2");
-                }
-                1 => {
-                    rvv_asm!("vrsub.vi v24, v8, 1");
-                }
-                0 => {
-                    rvv_asm!("vrsub.vi v24, v8, 0");
-                }
-                -1 => {
-                    rvv_asm!("vrsub.vi v24, v8, -1");
-                }
-                -2 => {
-                    rvv_asm!("vrsub.vi v24, v8, -2");
-                }
-                -3 => {
-                    rvv_asm!("vrsub.vi v24, v8, -3");
-                }
-                -4 => {
-                    rvv_asm!("vrsub.vi v24, v8, -4");
-                }
-                -5 => {
-                    rvv_asm!("vrsub.vi v24, v8, -5");
-                }
-                -6 => {
-                    rvv_asm!("vrsub.vi v24, v8, -6");
-                }
-                -7 => {
-                    rvv_asm!("vrsub.vi v24, v8, -7");
-                }
-                -8 => {
-                    rvv_asm!("vrsub.vi v24, v8, -8");
-                }
-                -9 => {
-                    rvv_asm!("vrsub.vi v24, v8, -9");
-                }
-                -10 => {
-                    rvv_asm!("vrsub.vi v24, v8, -10");
-                }
-                -11 => {
-                    rvv_asm!("vrsub.vi v24, v8, -11");
-                }
-                -12 => {
-                    rvv_asm!("vrsub.vi v24, v8, -12");
-                }
-                -13 => {
-                    rvv_asm!("vrsub.vi v24, v8, -13");
-                }
-                -14 => {
-                    rvv_asm!("vrsub.vi v24, v8, -14");
-                }
-                -15 => {
-                    rvv_asm!("vrsub.vi v24, v8, -15");
-                }
-                -16 => {
-                    rvv_asm!("vrsub.vi v24, v8, -16");
-                }
+                -16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, -1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, -1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vrsub.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vrsub.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("can't support this immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
 
-    run_template_v_vi(expected_op_sub, op, true, "vrsub.vi");
+    run_template_v_vi(expected_op_sub, op, true, true, "vrsub.vi");
 }
 
 fn expected_op_and(lhs: &[u8], imm: i64, result: &mut [u8]) {
@@ -352,113 +754,315 @@ fn expected_op_and(lhs: &[u8], imm: i64, result: &mut [u8]) {
     }
 }
 fn test_vand_vi() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                15 => {
-                    rvv_asm!("vand.vi v24, v8, 15");
-                }
-                14 => {
-                    rvv_asm!("vand.vi v24, v8, 14");
-                }
-                13 => {
-                    rvv_asm!("vand.vi v24, v8, 13");
-                }
-                12 => {
-                    rvv_asm!("vand.vi v24, v8, 12");
-                }
-                11 => {
-                    rvv_asm!("vand.vi v24, v8, 11");
-                }
-                10 => {
-                    rvv_asm!("vand.vi v24, v8, 10");
-                }
-                9 => {
-                    rvv_asm!("vand.vi v24, v8, 9");
-                }
-                8 => {
-                    rvv_asm!("vand.vi v24, v8, 8");
-                }
-                7 => {
-                    rvv_asm!("vand.vi v24, v8, 7");
-                }
-                6 => {
-                    rvv_asm!("vand.vi v24, v8, 6");
-                }
-                5 => {
-                    rvv_asm!("vand.vi v24, v8, 5");
-                }
-                4 => {
-                    rvv_asm!("vand.vi v24, v8, 4");
-                }
-                3 => {
-                    rvv_asm!("vand.vi v24, v8, 3");
-                }
-                2 => {
-                    rvv_asm!("vand.vi v24, v8, 2");
-                }
-                1 => {
-                    rvv_asm!("vand.vi v24, v8, 1");
-                }
-                0 => {
-                    rvv_asm!("vand.vi v24, v8, 0");
-                }
-                -1 => {
-                    rvv_asm!("vand.vi v24, v8, -1");
-                }
-                -2 => {
-                    rvv_asm!("vand.vi v24, v8, -2");
-                }
-                -3 => {
-                    rvv_asm!("vand.vi v24, v8, -3");
-                }
-                -4 => {
-                    rvv_asm!("vand.vi v24, v8, -4");
-                }
-                -5 => {
-                    rvv_asm!("vand.vi v24, v8, -5");
-                }
-                -6 => {
-                    rvv_asm!("vand.vi v24, v8, -6");
-                }
-                -7 => {
-                    rvv_asm!("vand.vi v24, v8, -7");
-                }
-                -8 => {
-                    rvv_asm!("vand.vi v24, v8, -8");
-                }
-                -9 => {
-                    rvv_asm!("vand.vi v24, v8, -9");
-                }
-                -10 => {
-                    rvv_asm!("vand.vi v24, v8, -10");
-                }
-                -11 => {
-                    rvv_asm!("vand.vi v24, v8, -11");
-                }
-                -12 => {
-                    rvv_asm!("vand.vi v24, v8, -12");
-                }
-                -13 => {
-                    rvv_asm!("vand.vi v24, v8, -13");
-                }
-                -14 => {
-                    rvv_asm!("vand.vi v24, v8, -14");
-                }
-                -15 => {
-                    rvv_asm!("vand.vi v24, v8, -15");
-                }
-                -16 => {
-                    rvv_asm!("vand.vi v24, v8, -16");
-                }
+                -16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, -1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, -1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vand.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vand.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("can't support this immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
-    run_template_v_vi(expected_op_and, op, true, "vand.vi");
+
+    run_template_v_vi(expected_op_and, op, true, true, "vand.vi");
 }
 
 fn expected_op_or(lhs: &[u8], imm: i64, result: &mut [u8]) {
@@ -502,113 +1106,315 @@ fn expected_op_or(lhs: &[u8], imm: i64, result: &mut [u8]) {
     }
 }
 fn test_vor_vi() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                15 => {
-                    rvv_asm!("vor.vi v24, v8, 15");
-                }
-                14 => {
-                    rvv_asm!("vor.vi v24, v8, 14");
-                }
-                13 => {
-                    rvv_asm!("vor.vi v24, v8, 13");
-                }
-                12 => {
-                    rvv_asm!("vor.vi v24, v8, 12");
-                }
-                11 => {
-                    rvv_asm!("vor.vi v24, v8, 11");
-                }
-                10 => {
-                    rvv_asm!("vor.vi v24, v8, 10");
-                }
-                9 => {
-                    rvv_asm!("vor.vi v24, v8, 9");
-                }
-                8 => {
-                    rvv_asm!("vor.vi v24, v8, 8");
-                }
-                7 => {
-                    rvv_asm!("vor.vi v24, v8, 7");
-                }
-                6 => {
-                    rvv_asm!("vor.vi v24, v8, 6");
-                }
-                5 => {
-                    rvv_asm!("vor.vi v24, v8, 5");
-                }
-                4 => {
-                    rvv_asm!("vor.vi v24, v8, 4");
-                }
-                3 => {
-                    rvv_asm!("vor.vi v24, v8, 3");
-                }
-                2 => {
-                    rvv_asm!("vor.vi v24, v8, 2");
-                }
-                1 => {
-                    rvv_asm!("vor.vi v24, v8, 1");
-                }
-                0 => {
-                    rvv_asm!("vor.vi v24, v8, 0");
-                }
-                -1 => {
-                    rvv_asm!("vor.vi v24, v8, -1");
-                }
-                -2 => {
-                    rvv_asm!("vor.vi v24, v8, -2");
-                }
-                -3 => {
-                    rvv_asm!("vor.vi v24, v8, -3");
-                }
-                -4 => {
-                    rvv_asm!("vor.vi v24, v8, -4");
-                }
-                -5 => {
-                    rvv_asm!("vor.vi v24, v8, -5");
-                }
-                -6 => {
-                    rvv_asm!("vor.vi v24, v8, -6");
-                }
-                -7 => {
-                    rvv_asm!("vor.vi v24, v8, -7");
-                }
-                -8 => {
-                    rvv_asm!("vor.vi v24, v8, -8");
-                }
-                -9 => {
-                    rvv_asm!("vor.vi v24, v8, -9");
-                }
-                -10 => {
-                    rvv_asm!("vor.vi v24, v8, -10");
-                }
-                -11 => {
-                    rvv_asm!("vor.vi v24, v8, -11");
-                }
-                -12 => {
-                    rvv_asm!("vor.vi v24, v8, -12");
-                }
-                -13 => {
-                    rvv_asm!("vor.vi v24, v8, -13");
-                }
-                -14 => {
-                    rvv_asm!("vor.vi v24, v8, -14");
-                }
-                -15 => {
-                    rvv_asm!("vor.vi v24, v8, -15");
-                }
-                -16 => {
-                    rvv_asm!("vor.vi v24, v8, -16");
-                }
+                -16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, -1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, -1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vor.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vor.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("can't support this immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
-    run_template_v_vi(expected_op_or, op, true, "vor.vi");
+
+    run_template_v_vi(expected_op_or, op, true, true, "vor.vi");
 }
 
 fn expected_op_xor(lhs: &[u8], imm: i64, result: &mut [u8]) {
@@ -652,114 +1458,315 @@ fn expected_op_xor(lhs: &[u8], imm: i64, result: &mut [u8]) {
     }
 }
 fn test_vxor_vi() {
-    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
         let imm = i64::from_le_bytes(rhs.try_into().unwrap());
         unsafe {
             match imm {
-                15 => {
-                    rvv_asm!("vxor.vi v24, v8, 15");
-                }
-                14 => {
-                    rvv_asm!("vxor.vi v24, v8, 14");
-                }
-                13 => {
-                    rvv_asm!("vxor.vi v24, v8, 13");
-                }
-                12 => {
-                    rvv_asm!("vxor.vi v24, v8, 12");
-                }
-                11 => {
-                    rvv_asm!("vxor.vi v24, v8, 11");
-                }
-                10 => {
-                    rvv_asm!("vxor.vi v24, v8, 10");
-                }
-                9 => {
-                    rvv_asm!("vxor.vi v24, v8, 9");
-                }
-                8 => {
-                    rvv_asm!("vxor.vi v24, v8, 8");
-                }
-                7 => {
-                    rvv_asm!("vxor.vi v24, v8, 7");
-                }
-                6 => {
-                    rvv_asm!("vxor.vi v24, v8, 6");
-                }
-                5 => {
-                    rvv_asm!("vxor.vi v24, v8, 5");
-                }
-                4 => {
-                    rvv_asm!("vxor.vi v24, v8, 4");
-                }
-                3 => {
-                    rvv_asm!("vxor.vi v24, v8, 3");
-                }
-                2 => {
-                    rvv_asm!("vxor.vi v24, v8, 2");
-                }
-                1 => {
-                    rvv_asm!("vxor.vi v24, v8, 1");
-                }
-                0 => {
-                    rvv_asm!("vxor.vi v24, v8, 0");
-                }
-                -1 => {
-                    rvv_asm!("vxor.vi v24, v8, -1");
-                }
-                -2 => {
-                    rvv_asm!("vxor.vi v24, v8, -2");
-                }
-                -3 => {
-                    rvv_asm!("vxor.vi v24, v8, -3");
-                }
-                -4 => {
-                    rvv_asm!("vxor.vi v24, v8, -4");
-                }
-                -5 => {
-                    rvv_asm!("vxor.vi v24, v8, -5");
-                }
-                -6 => {
-                    rvv_asm!("vxor.vi v24, v8, -6");
-                }
-                -7 => {
-                    rvv_asm!("vxor.vi v24, v8, -7");
-                }
-                -8 => {
-                    rvv_asm!("vxor.vi v24, v8, -8");
-                }
-                -9 => {
-                    rvv_asm!("vxor.vi v24, v8, -9");
-                }
-                -10 => {
-                    rvv_asm!("vxor.vi v24, v8, -10");
-                }
-                -11 => {
-                    rvv_asm!("vxor.vi v24, v8, -11");
-                }
-                -12 => {
-                    rvv_asm!("vxor.vi v24, v8, -12");
-                }
-                -13 => {
-                    rvv_asm!("vxor.vi v24, v8, -13");
-                }
-                -14 => {
-                    rvv_asm!("vxor.vi v24, v8, -14");
-                }
-                -15 => {
-                    rvv_asm!("vxor.vi v24, v8, -15");
-                }
-                -16 => {
-                    rvv_asm!("vxor.vi v24, v8, -16");
-                }
+                -16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -16");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                -1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, -1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, -1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                0 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 0, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 0");
+                    }
+                    _ => panic!("Abort"),
+                },
+                1 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 1, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 1");
+                    }
+                    _ => panic!("Abort"),
+                },
+                2 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 2, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 2");
+                    }
+                    _ => panic!("Abort"),
+                },
+                3 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 3, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 3");
+                    }
+                    _ => panic!("Abort"),
+                },
+                4 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 4, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 4");
+                    }
+                    _ => panic!("Abort"),
+                },
+                5 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 5, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 5");
+                    }
+                    _ => panic!("Abort"),
+                },
+                6 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 6, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 6");
+                    }
+                    _ => panic!("Abort"),
+                },
+                7 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 7, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 7");
+                    }
+                    _ => panic!("Abort"),
+                },
+                8 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 8, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 8");
+                    }
+                    _ => panic!("Abort"),
+                },
+                9 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 9, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 9");
+                    }
+                    _ => panic!("Abort"),
+                },
+                10 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 10, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 10");
+                    }
+                    _ => panic!("Abort"),
+                },
+                11 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 11, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 11");
+                    }
+                    _ => panic!("Abort"),
+                },
+                12 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 12, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 12");
+                    }
+                    _ => panic!("Abort"),
+                },
+                13 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 13, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 13");
+                    }
+                    _ => panic!("Abort"),
+                },
+                14 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 14, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 14");
+                    }
+                    _ => panic!("Abort"),
+                },
+                15 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 15, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 15");
+                    }
+                    _ => panic!("Abort"),
+                },
+                16 => match mask_type {
+                    MaskType::Enable => {
+                        rvv_asm!("vxor.vi v24, v8, 16, v0.t");
+                    }
+                    MaskType::Disable => {
+                        rvv_asm!("vxor.vi v24, v8, 16");
+                    }
+                    _ => panic!("Abort"),
+                },
                 _ => {
-                    panic!("can't support this immediate: {}", imm);
+                    panic!("Abort");
                 }
             }
         }
     }
 
-    run_template_v_vi(expected_op_xor, op, true, "vxor.vi");
+    run_template_v_vi(expected_op_xor, op, true, true, "vxor.vi");
 }
 
 pub fn test_vop_vi() {

--- a/cases/src/vop_vi_cases.rs
+++ b/cases/src/vop_vi_cases.rs
@@ -1,9 +1,8 @@
 use core::arch::asm;
 use core::convert::TryInto;
 use rvv_asm::rvv_asm;
-use rvv_testcases::intrinsic::vop_vi;
-use rvv_testcases::misc::{avl_iterator, Widening, U256};
-use rvv_testcases::runner::{run_vop_vi, WideningCategory};
+use rvv_testcases::misc::{Widening, U256};
+use rvv_testcases::runner::{run_template_v_vi, MaskType};
 
 fn expected_op_add(lhs: &[u8], imm: i64, result: &mut [u8]) {
     assert!(lhs.len() == result.len());
@@ -46,10 +45,11 @@ fn expected_op_add(lhs: &[u8], imm: i64, result: &mut [u8]) {
         }
     }
 }
-fn test_vadd_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
+fn test_vadd_vi() {
     // test combinations of lmul, sew, avl, etc
-    fn add(lhs: &[u8], imm: i64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vi(lhs, imm, result, sew, avl, lmul, |imm| unsafe {
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
             match imm {
                 15 => {
                     rvv_asm!("vadd.vi v24, v8, 15");
@@ -151,18 +151,9 @@ fn test_vadd_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
                     panic!("can't support this immediate: {}", imm);
                 }
             }
-        });
+        }
     }
-    run_vop_vi(
-        sew,
-        lmul,
-        avl,
-        imm,
-        expected_op_add,
-        add,
-        WideningCategory::None,
-        "vadd.vi",
-    );
+    run_template_v_vi(expected_op_add, op, true, "vadd.vi");
 }
 
 fn expected_op_sub(lhs: &[u8], imm: i64, result: &mut [u8]) {
@@ -209,9 +200,10 @@ fn expected_op_sub(lhs: &[u8], imm: i64, result: &mut [u8]) {
         }
     }
 }
-fn test_vrsub_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
-    fn sub(lhs: &[u8], imm: i64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vi(lhs, imm, result, sew, avl, lmul, |imm| unsafe {
+fn test_vrsub_vi() {
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
             match imm {
                 15 => {
                     rvv_asm!("vrsub.vi v24, v8, 15");
@@ -313,18 +305,10 @@ fn test_vrsub_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
                     panic!("can't support this immediate: {}", imm);
                 }
             }
-        });
+        }
     }
-    run_vop_vi(
-        sew,
-        lmul,
-        avl,
-        imm,
-        expected_op_sub,
-        sub,
-        WideningCategory::None,
-        "vrsub.vi",
-    );
+
+    run_template_v_vi(expected_op_sub, op, true, "vrsub.vi");
 }
 
 fn expected_op_and(lhs: &[u8], imm: i64, result: &mut [u8]) {
@@ -367,9 +351,10 @@ fn expected_op_and(lhs: &[u8], imm: i64, result: &mut [u8]) {
         }
     }
 }
-fn test_vand_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
-    fn and(lhs: &[u8], imm: i64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vi(lhs, imm, result, sew, avl, lmul, |imm| unsafe {
+fn test_vand_vi() {
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
             match imm {
                 15 => {
                     rvv_asm!("vand.vi v24, v8, 15");
@@ -471,18 +456,9 @@ fn test_vand_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
                     panic!("can't support this immediate: {}", imm);
                 }
             }
-        });
+        }
     }
-    run_vop_vi(
-        sew,
-        lmul,
-        avl,
-        imm,
-        expected_op_and,
-        and,
-        WideningCategory::None,
-        "vand.vi",
-    );
+    run_template_v_vi(expected_op_and, op, true, "vand.vi");
 }
 
 fn expected_op_or(lhs: &[u8], imm: i64, result: &mut [u8]) {
@@ -525,9 +501,10 @@ fn expected_op_or(lhs: &[u8], imm: i64, result: &mut [u8]) {
         }
     }
 }
-fn test_vor_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
-    fn or(lhs: &[u8], imm: i64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vi(lhs, imm, result, sew, avl, lmul, |imm| unsafe {
+fn test_vor_vi() {
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
             match imm {
                 15 => {
                     rvv_asm!("vor.vi v24, v8, 15");
@@ -629,18 +606,9 @@ fn test_vor_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
                     panic!("can't support this immediate: {}", imm);
                 }
             }
-        });
+        }
     }
-    run_vop_vi(
-        sew,
-        lmul,
-        avl,
-        imm,
-        expected_op_or,
-        or,
-        WideningCategory::None,
-        "vor.vi",
-    );
+    run_template_v_vi(expected_op_or, op, true, "vor.vi");
 }
 
 fn expected_op_xor(lhs: &[u8], imm: i64, result: &mut [u8]) {
@@ -683,9 +651,10 @@ fn expected_op_xor(lhs: &[u8], imm: i64, result: &mut [u8]) {
         }
     }
 }
-fn test_vxor_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
-    fn xor(lhs: &[u8], imm: i64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vi(lhs, imm, result, sew, avl, lmul, |imm| unsafe {
+fn test_vxor_vi() {
+    fn op(_: &[u8], rhs: &[u8], _: MaskType) {
+        let imm = i64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
             match imm {
                 15 => {
                     rvv_asm!("vxor.vi v24, v8, 15");
@@ -787,36 +756,16 @@ fn test_vxor_vi(sew: u64, lmul: i64, avl: u64, imm: i64) {
                     panic!("can't support this immediate: {}", imm);
                 }
             }
-        });
+        }
     }
 
-    run_vop_vi(
-        sew,
-        lmul,
-        avl,
-        imm,
-        expected_op_xor,
-        xor,
-        WideningCategory::None,
-        "vxor.vi",
-    );
+    run_template_v_vi(expected_op_xor, op, true, "vxor.vi");
 }
 
 pub fn test_vop_vi() {
-    let mut imm = -16;
-    for sew in [8, 32, 64, 128, 256] {
-        for lmul in [-2, 1, 4, 8] {
-            for avl in avl_iterator(sew, 4) {
-                test_vadd_vi(sew, lmul, avl, imm);
-                test_vrsub_vi(sew, lmul, avl, imm);
-                test_vand_vi(sew, lmul, avl, imm);
-                test_vor_vi(sew, lmul, avl, imm);
-                test_vxor_vi(sew, lmul, avl, imm);
-                imm += 1;
-                if imm > 15 {
-                    imm = -16;
-                }
-            }
-        }
-    }
+    test_vadd_vi();
+    test_vrsub_vi();
+    test_vand_vi();
+    test_vor_vi();
+    test_vxor_vi();
 }

--- a/cases/src/vop_vv_cases.rs
+++ b/cases/src/vop_vv_cases.rs
@@ -467,7 +467,7 @@ fn expected_op_rem(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
             if r == 0 {
                 result.copy_from_slice(lhs);
             } else {
-                let res = l % r;
+                let res = l.wrapping_rem( r);
                 result.copy_from_slice(&res.to_le_bytes());
             }
         }

--- a/cases/src/vop_vv_cases.rs
+++ b/cases/src/vop_vv_cases.rs
@@ -1,14 +1,14 @@
-use core::arch::asm;
-use core::cmp::Ordering::{Greater, Less};
-use core::convert::TryInto;
-
-use alloc::boxed::Box;
+use core::{
+    arch::asm,
+    cmp::Ordering::{Greater, Less},
+    convert::TryInto,
+};
 use eint::{Eint, E256};
 use rvv_asm::rvv_asm;
-use rvv_testcases::intrinsic::vop_vv;
-
-use rvv_testcases::misc::{avl_iterator, U1024, U256, U512};
-use rvv_testcases::runner::{run_vop_vv, ExpectedOp, WideningCategory};
+use rvv_testcases::{
+    misc::{U1024, U256, U512},
+    runner::{run_template_v_vv, MaskType},
+};
 
 fn expected_op_add(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
     assert!(lhs.len() == rhs.len() && rhs.len() == result.len());
@@ -57,22 +57,21 @@ fn expected_op_add(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vadd_vv(sew: u64, lmul: i64, avl: u64) {
-    fn add(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vadd.vv v24, v8, v16");
-        });
+fn test_vadd_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vadd.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vadd.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_add)),
-        add,
-        WideningCategory::None,
-        "vadd.vv",
-    );
+    run_template_v_vv(expected_op_add, op, true, "vadd.vv");
 }
 
 fn expected_op_mul(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -96,22 +95,21 @@ fn expected_op_mul(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmul_vv(sew: u64, lmul: i64, avl: u64) {
-    fn mul(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vmul.vv v24, v8, v16");
-        });
+fn test_vmul_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vmul.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vmul.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_mul)),
-        mul,
-        WideningCategory::None,
-        "vmul.vv",
-    );
+    run_template_v_vv(expected_op_mul, op, true, "vmul.vv");
 }
 
 fn expected_op_and(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -134,22 +132,21 @@ fn expected_op_and(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vand_vv(sew: u64, lmul: i64, avl: u64) {
-    fn and(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vand.vv v24, v8, v16");
-        });
+fn test_vand_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vand.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vand.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_and)),
-        and,
-        WideningCategory::None,
-        "vand.vv",
-    );
+    run_template_v_vv(expected_op_and, op, true, "vand.vv");
 }
 
 fn expected_op_or(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -172,22 +169,21 @@ fn expected_op_or(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vor_vv(sew: u64, lmul: i64, avl: u64) {
-    fn or(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vor.vv v24, v8, v16");
-        });
+fn test_vor_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vor.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vor.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_or)),
-        or,
-        WideningCategory::None,
-        "vor.vv",
-    );
+    run_template_v_vv(expected_op_or, op, true, "vor.vv");
 }
 
 fn expected_op_xor(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -210,22 +206,21 @@ fn expected_op_xor(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vxor_vv(sew: u64, lmul: i64, avl: u64) {
-    fn xor(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vxor.vv v24, v8, v16");
-        });
+fn test_vxor_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vxor.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vxor.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_xor)),
-        xor,
-        WideningCategory::None,
-        "vxor.vv",
-    );
+    run_template_v_vv(expected_op_xor, op, true, "vxor.vv");
 }
 
 fn expected_op_mulh(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -248,22 +243,21 @@ fn expected_op_mulh(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmulh_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vmulh.vv v24, v8, v16");
-        });
+fn test_vmulh_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vmulh.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vmulh.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_mulh)),
-        op,
-        WideningCategory::None,
-        "vmulh.vv",
-    );
+    run_template_v_vv(expected_op_mulh, op, true, "vmulh.vv");
 }
 
 fn expected_op_mulhu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -286,22 +280,21 @@ fn expected_op_mulhu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmulhu_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vmulhu.vv v24, v8, v16");
-        });
+fn test_vmulhu_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vmulhu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vmulhu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_mulhu)),
-        op,
-        WideningCategory::None,
-        "vmulhu.vv",
-    );
+    run_template_v_vv(expected_op_mulhu, op, true, "vmulhu.vv");
 }
 
 fn expected_op_mulhsu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -325,23 +318,21 @@ fn expected_op_mulhsu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmulhsu_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vmulhsu.vv v24, v8, v16");
-        });
+fn test_vmulhsu_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vmulhsu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vmulhsu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_mulhsu)),
-        op,
-        WideningCategory::None,
-        "vmulhsu.vv",
-    );
+    run_template_v_vv(expected_op_mulhsu, op, true, "vmulhsu.vv");
 }
 
 fn expected_op_divu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -368,23 +359,21 @@ fn expected_op_divu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vdivu_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vdivu.vv v24, v8, v16");
-        });
+fn test_vdivu_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vdivu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vdivu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_divu)),
-        op,
-        WideningCategory::None,
-        "vdivu.vv",
-    );
+    run_template_v_vv(expected_op_divu, op, true, "vdivu.vv");
 }
 
 fn expected_op_div(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -411,23 +400,21 @@ fn expected_op_div(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vdiv_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vdiv.vv v24, v8, v16");
-        });
+fn test_vdiv_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vdiv.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vdiv.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_div)),
-        op,
-        WideningCategory::None,
-        "vdiv.vv",
-    );
+    run_template_v_vv(expected_op_div, op, true, "vdiv.vv");
 }
 
 fn expected_op_remu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -454,23 +441,21 @@ fn expected_op_remu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vremu_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vremu.vv v24, v8, v16");
-        });
+fn test_vremu_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vremu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vremu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_remu)),
-        op,
-        WideningCategory::None,
-        "vremu.vv",
-    );
+    run_template_v_vv(expected_op_remu, op, true, "vremu.vv");
 }
 
 fn expected_op_rem(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -497,23 +482,21 @@ fn expected_op_rem(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vrem_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vrem.vv v24, v8, v16");
-        });
+fn test_vrem_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vrem.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vrem.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_rem)),
-        op,
-        WideningCategory::None,
-        "vrem.vv",
-    );
+    run_template_v_vv(expected_op_rem, op, true, "vrem.vv");
 }
 
 fn expected_op_minu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -541,23 +524,21 @@ fn expected_op_minu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vminu_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vminu.vv v24, v8, v16");
-        });
+fn test_vminu_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vminu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vminu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_minu)),
-        op,
-        WideningCategory::None,
-        "vminu.vv",
-    );
+    run_template_v_vv(expected_op_minu, op, true, "vminu.vv");
 }
 
 fn expected_op_min(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -585,23 +566,21 @@ fn expected_op_min(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmin_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vmin.vv v24, v8, v16");
-        });
+fn test_vmin_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vmin.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vmin.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_min)),
-        op,
-        WideningCategory::None,
-        "vmin.vv",
-    );
+    run_template_v_vv(expected_op_min, op, true, "vmin.vv");
 }
 
 fn expected_op_maxu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -629,23 +608,21 @@ fn expected_op_maxu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmaxu_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vmaxu.vv v24, v8, v16");
-        });
+fn test_vmaxu_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vmaxu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vmaxu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_maxu)),
-        op,
-        WideningCategory::None,
-        "vmaxu.vv",
-    );
+    run_template_v_vv(expected_op_maxu, op, true, "vmaxu.vv");
 }
 
 fn expected_op_max(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -673,23 +650,21 @@ fn expected_op_max(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmax_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vmax.vv v24, v8, v16");
-        });
+fn test_vmax_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vmax.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vmax.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_max)),
-        op,
-        WideningCategory::None,
-        "vmax.vv",
-    );
+    run_template_v_vv(expected_op_max, op, true, "vmax.vv");
 }
 
 fn expected_op_smul(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -714,47 +689,39 @@ fn expected_op_smul(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-
-fn test_vsmul_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vsmul.vv v24, v8, v16");
-        });
-    }
-
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_smul)),
-        op,
-        WideningCategory::None,
-        "vsmul.vv",
-    );
-}
-
-pub fn test_vop_vv() {
-    for sew in [64, 256] {
-        for lmul in [-8, -2, 1, 4, 8] {
-            for avl in avl_iterator(sew, 4) {
-                test_vadd_vv(sew, lmul, avl);
-                test_vmul_vv(sew, lmul, avl);
-                test_vand_vv(sew, lmul, avl);
-                test_vor_vv(sew, lmul, avl);
-                test_vxor_vv(sew, lmul, avl);
-                test_vmulh_vv(sew, lmul, avl);
-                test_vmulhu_vv(sew, lmul, avl);
-                test_vmulhsu_vv(sew, lmul, avl);
-                test_vdivu_vv(sew, lmul, avl);
-                test_vdiv_vv(sew, lmul, avl);
-                test_vremu_vv(sew, lmul, avl);
-                test_vrem_vv(sew, lmul, avl);
-                test_vminu_vv(sew, lmul, avl);
-                test_vmin_vv(sew, lmul, avl);
-                test_vmaxu_vv(sew, lmul, avl);
-                test_vmax_vv(sew, lmul, avl);
-                test_vsmul_vv(sew, lmul, avl);
+fn test_vsmul_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vsmul.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vsmul.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
             }
         }
     }
+    run_template_v_vv(expected_op_smul, op, true, "vsmul.vv");
+}
+
+pub fn test_vop_vv() {
+    test_vadd_vv();
+    test_vmul_vv();
+    test_vand_vv();
+    test_vor_vv();
+    test_vxor_vv();
+    test_vmulh_vv();
+    test_vmulhu_vv();
+    test_vmulhsu_vv();
+    test_vdivu_vv();
+    test_vdiv_vv();
+    test_vremu_vv();
+    test_vrem_vv();
+    test_vminu_vv();
+    test_vmin_vv();
+    test_vmaxu_vv();
+    test_vmax_vv();
+    test_vsmul_vv();
 }

--- a/cases/src/vop_vx_cases.rs
+++ b/cases/src/vop_vx_cases.rs
@@ -3,9 +3,10 @@ use core::cmp::Ordering::{Greater, Less};
 use core::convert::TryInto;
 use eint::{Eint, E128, E256};
 use rvv_asm::rvv_asm;
-use rvv_testcases::intrinsic::vop_vx;
-use rvv_testcases::misc::{avl_iterator, Widening, U256};
-use rvv_testcases::runner::{run_vop_vx, WideningCategory};
+use rvv_testcases::{
+    misc::{Widening, U256},
+    runner::{run_template_v_vx, MaskType},
+};
 
 fn expected_op_add(lhs: &[u8], x: u64, result: &mut [u8]) {
     assert_eq!(lhs.len(), result.len());
@@ -38,24 +39,22 @@ fn expected_op_add(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vadd_vx(sew: u64, lmul: i64, avl: u64) {
-    fn add(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vadd.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vadd_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vadd.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vadd.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_add,
-        add,
-        WideningCategory::None,
-        "vadd.vx",
-    );
+    run_template_v_vx(expected_op_add, op, true, "vadd.vx");
 }
 
 fn expected_op_sub(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -90,24 +89,22 @@ fn expected_op_sub(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vsub_vx(sew: u64, lmul: i64, avl: u64) {
-    fn sub(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vsub.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vsub_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vsub.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vsub.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_sub,
-        sub,
-        WideningCategory::None,
-        "vsub.vx",
-    );
+    run_template_v_vx(expected_op_sub, op, true, "vsub.vx");
 }
 
 fn expected_op_rsub(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -143,24 +140,22 @@ fn expected_op_rsub(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vrsub_vx(sew: u64, lmul: i64, avl: u64) {
-    fn rsub(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vrsub.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vrsub_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vrsub.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vrsub.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_rsub,
-        rsub,
-        WideningCategory::None,
-        "vrsub.vx",
-    );
+    run_template_v_vx(expected_op_rsub, op, true, "vrsub.vx");
 }
 
 fn expected_op_and(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -194,24 +189,22 @@ fn expected_op_and(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vand_vx(sew: u64, lmul: i64, avl: u64) {
-    fn and(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vand.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vand_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vand.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vand.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_and,
-        and,
-        WideningCategory::None,
-        "vand.vx",
-    );
+    run_template_v_vx(expected_op_and, op, true, "vand.vx");
 }
 
 fn expected_op_or(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -245,24 +238,22 @@ fn expected_op_or(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vor_vx(sew: u64, lmul: i64, avl: u64) {
-    fn or(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vor.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vor_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vor.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vor.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_or,
-        or,
-        WideningCategory::None,
-        "vor.vx",
-    );
+    run_template_v_vx(expected_op_or, op, true, "vor.vx");
 }
 
 fn expected_op_xor(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -296,24 +287,22 @@ fn expected_op_xor(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vxor_vx(sew: u64, lmul: i64, avl: u64) {
-    fn xor(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vxor.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vxor_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vxor.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vxor.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_xor,
-        xor,
-        WideningCategory::None,
-        "vxor.vx",
-    );
+    run_template_v_vx(expected_op_xor, op, true, "vxor.vx");
 }
 
 fn expected_op_mul(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -348,24 +337,22 @@ fn expected_op_mul(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmul_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vmul.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vmul_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmul.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmul.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_mul,
-        op,
-        WideningCategory::None,
-        "vmul.vx",
-    );
+    run_template_v_vx(expected_op_mul, op, true, "vmul.vx");
 }
 
 fn expected_op_mulh(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -402,25 +389,22 @@ fn expected_op_mulh(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmulh_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vmulh.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vmulh_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmulh.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmulh.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_mulh,
-        op,
-        WideningCategory::None,
-        "vmulh.vx",
-    );
+    run_template_v_vx(expected_op_mulh, op, true, "vmulh.vx");
 }
 
 fn expected_op_mulhu(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -456,25 +440,22 @@ fn expected_op_mulhu(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmulhu_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vmulhu.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vmulhu_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmulhu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmulhu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_mulhu,
-        op,
-        WideningCategory::None,
-        "vmulhu.vx",
-    );
+    run_template_v_vx(expected_op_mulhu, op, true, "vmulhu.vx");
 }
 
 fn expected_op_mulhsu(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -510,25 +491,22 @@ fn expected_op_mulhsu(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmulhsu_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vmulhsu.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vmulhsu_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmulhsu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmulhsu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_mulhsu,
-        op,
-        WideningCategory::None,
-        "vmulhsu.vx",
-    );
+    run_template_v_vx(expected_op_mulhsu, op, true, "vmulhsu.vx");
 }
 
 fn expected_op_divu(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -588,25 +566,22 @@ fn expected_op_divu(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vdivu_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vdivu.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vdivu_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vdivu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vdivu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_divu,
-        op,
-        WideningCategory::None,
-        "vdivu.vx",
-    );
+    run_template_v_vx(expected_op_divu, op, true, "vdivu.vx");
 }
 
 fn expected_op_div(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -666,25 +641,22 @@ fn expected_op_div(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vdiv_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vdiv.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vdiv_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vdiv.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vdiv.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_div,
-        op,
-        WideningCategory::None,
-        "vdiv.vx",
-    );
+    run_template_v_vx(expected_op_div, op, true, "vdiv.vx");
 }
 
 fn expected_op_remu(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -744,25 +716,22 @@ fn expected_op_remu(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vremu_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vremu.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vremu_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vremu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vremu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_remu,
-        op,
-        WideningCategory::None,
-        "vremu.vx",
-    );
+    run_template_v_vx(expected_op_remu, op, true, "vremu.vx");
 }
 
 fn expected_op_rem(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -823,25 +792,22 @@ fn expected_op_rem(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vrem_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vrem.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vrem_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vrem.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vrem.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_rem,
-        op,
-        WideningCategory::None,
-        "vrem.vx",
-    );
+    run_template_v_vx(expected_op_rem, op, true, "vrem.vx");
 }
 
 fn expected_op_minu(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -884,7 +850,7 @@ fn expected_op_minu(lhs: &[u8], x: u64, result: &mut [u8]) {
             if l.cmp_u(&r) == Less {
                 result.copy_from_slice(lhs);
             } else {
-                result[..8].copy_from_slice(x.to_le_bytes().as_slice());
+                r.put(result);
             }
         }
         _ => {
@@ -892,25 +858,22 @@ fn expected_op_minu(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vminu_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vminu.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vminu_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vminu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vminu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_minu,
-        op,
-        WideningCategory::None,
-        "vminu.vx",
-    );
+    run_template_v_vx(expected_op_minu, op, true, "vminu.vx");
 }
 
 fn expected_op_min(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -965,25 +928,22 @@ fn expected_op_min(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmin_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vmin.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vmin_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmin.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmin.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_min,
-        op,
-        WideningCategory::None,
-        "vmin.vx",
-    );
+    run_template_v_vx(expected_op_min, op, true, "vmin.vx");
 }
 
 fn expected_op_maxu(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -1034,25 +994,22 @@ fn expected_op_maxu(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmaxu_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vmaxu.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vmaxu_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmaxu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmaxu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_maxu,
-        op,
-        WideningCategory::None,
-        "vmaxu.vx",
-    );
+    run_template_v_vx(expected_op_maxu, op, true, "vmaxu.vx");
 }
 
 fn expected_op_max(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -1107,25 +1064,22 @@ fn expected_op_max(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vmax_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vmax.vx v24, v8, t0",
-                     in (reg) x);
-        });
+fn test_vmax_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vmax.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vmax.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_max,
-        op,
-        WideningCategory::None,
-        "vmax.vx",
-    );
+    run_template_v_vx(expected_op_max, op, true, "vmax.vx");
 }
 
 fn expected_op_smul(lhs: &[u8], x: u64, result: &mut [u8]) {
@@ -1170,52 +1124,42 @@ fn expected_op_smul(lhs: &[u8], x: u64, result: &mut [u8]) {
         }
     }
 }
-
-fn test_vsmul_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", 
-                     "vsmul.vx v24, v8, t0",
-                     in (reg) x);
-        });
-    }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_smul,
-        op,
-        WideningCategory::None,
-        "vsmul.vx",
-    );
-}
-
-pub fn test_vop_vx() {
-    // test combinations of lmul, sew, avl, etc
-    for sew in [8, 16, 32, 64, 256] {
-        for lmul in [-2, 1, 4, 8] {
-            for avl in avl_iterator(sew, 4) {
-                test_vadd_vx(sew, lmul, avl);
-                test_vsub_vx(sew, lmul, avl);
-                test_vrsub_vx(sew, lmul, avl);
-                test_vand_vx(sew, lmul, avl);
-                test_vor_vx(sew, lmul, avl);
-                test_vxor_vx(sew, lmul, avl);
-                test_vmul_vx(sew, lmul, avl);
-                test_vmulh_vx(sew, lmul, avl);
-                test_vmulhu_vx(sew, lmul, avl);
-                test_vmulhsu_vx(sew, lmul, avl);
-                test_vdivu_vx(sew, lmul, avl);
-                test_vdiv_vx(sew, lmul, avl);
-                test_vremu_vx(sew, lmul, avl);
-                test_vrem_vx(sew, lmul, avl);
-                test_vminu_vx(sew, lmul, avl);
-                test_vmin_vx(sew, lmul, avl);
-                test_vmaxu_vx(sew, lmul, avl);
-                test_vmax_vx(sew, lmul, avl);
-                test_vsmul_vx(sew, lmul, avl);
+fn test_vsmul_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vsmul.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vsmul.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
             }
         }
     }
+    run_template_v_vx(expected_op_smul, op, true, "vsmul.vx");
+}
+
+pub fn test_vop_vx() {
+    test_vadd_vx();
+    test_vsub_vx();
+    test_vrsub_vx();
+    test_vand_vx();
+    test_vor_vx();
+    test_vxor_vx();
+    test_vmul_vx();
+    test_vmulh_vx();
+    test_vmulhu_vx();
+    test_vmulhsu_vx();
+    test_vdivu_vx();
+    test_vdiv_vx();
+    test_vremu_vx();
+    test_vrem_vx();
+    test_vminu_vx();
+    test_vmin_vx();
+    test_vmaxu_vx();
+    test_vmax_vx();
+    test_vsmul_vx();
 }

--- a/cases/src/vwop_vv_cases.rs
+++ b/cases/src/vwop_vv_cases.rs
@@ -1,11 +1,9 @@
-use alloc::boxed::Box;
 use core::{arch::asm, convert::TryInto};
 use eint::{Eint, E256, E512};
 use rvv_asm::rvv_asm;
 use rvv_testcases::{
-    intrinsic::vwop_vv,
-    misc::{avl_iterator, conver_to_i512},
-    runner::{run_vop_vv, ExpectedOp, WideningCategory},
+    misc::conver_to_i512,
+    runner::{run_template_w_vv, MaskType},
 };
 
 fn expected_op_addu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -27,21 +25,21 @@ fn expected_op_addu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vw_addu_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vwaddu.vv v24, v8, v16");
-        });
+fn test_vw_addu_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vwaddu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vwaddu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_addu)),
-        op,
-        WideningCategory::VdOnly,
-        "vwaddu.vv",
-    );
+    run_template_w_vv(expected_op_addu, op, true, "vwaddu.vv");
 }
 
 fn expected_op_add(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -63,21 +61,21 @@ fn expected_op_add(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vw_add_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vwadd.vv v24, v8, v16");
-        });
+fn test_vw_add_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vwadd.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vwadd.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_add)),
-        op,
-        WideningCategory::VdOnly,
-        "vwadd.vv",
-    );
+    run_template_w_vv(expected_op_add, op, true, "vwadd.vv");
 }
 
 fn expected_op_mulu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -99,21 +97,21 @@ fn expected_op_mulu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vw_mulu_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vwmulu.vv v24, v8, v16");
-        });
+fn test_vw_mulu_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vwmulu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vwmulu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_mulu)),
-        op,
-        WideningCategory::VdOnly,
-        "vwmulu.vv",
-    );
+    run_template_w_vv(expected_op_mulu, op, true, "vwmulu.vv");
 }
 
 fn expected_op_mul(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -135,21 +133,21 @@ fn expected_op_mul(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vw_mul_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vwmul.vv v24, v8, v16");
-        });
+fn test_vw_mul_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vwmul.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vwmul.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_mul)),
-        op,
-        WideningCategory::VdOnly,
-        "vwmul.vv",
-    );
+    run_template_w_vv(expected_op_mul, op, true, "vwmul.vv");
 }
 
 fn expected_op_mulsu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -171,21 +169,21 @@ fn expected_op_mulsu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vw_mulsu_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vwmulsu.vv v24, v8, v16");
-        });
+fn test_vw_mulsu_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vwmulsu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vwmulsu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_mulsu)),
-        op,
-        WideningCategory::VdOnly,
-        "vwmulsu.vv",
-    );
+    run_template_w_vv(expected_op_mulsu, op, true, "vwmulsu.vv");
 }
 
 fn expected_op_subu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -207,21 +205,21 @@ fn expected_op_subu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vw_subu_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vwsubu.vv v24, v8, v16");
-        });
+fn test_vw_subu_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vwsubu.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vwsubu.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_subu)),
-        op,
-        WideningCategory::VdOnly,
-        "vwsubu.vv",
-    );
+    run_template_w_vv(expected_op_subu, op, true, "vwsubu.vv");
 }
 
 fn expected_op_sub(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -243,35 +241,29 @@ fn expected_op_sub(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vw_sub_vv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vwsub.vv v24, v8, v16");
-        });
-    }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_sub)),
-        op,
-        WideningCategory::VdOnly,
-        "vwsub.vv",
-    );
-}
-
-pub fn test_vwop_vv() {
-    for sew in [64, 256] {
-        for lmul in [-2, 1, 2] {
-            for avl in avl_iterator(sew, 4) {
-                test_vw_addu_vv(sew, lmul, avl);
-                test_vw_add_vv(sew, lmul, avl);
-                test_vw_mulu_vv(sew, lmul, avl);
-                test_vw_mul_vv(sew, lmul, avl);
-                test_vw_mulsu_vv(sew, lmul, avl);
-                test_vw_subu_vv(sew, lmul, avl);
-                test_vw_sub_vv(sew, lmul, avl);
+fn test_vw_sub_vv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vwsub.vv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vwsub.vv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
             }
         }
     }
+    run_template_w_vv(expected_op_sub, op, true, "vwsub.vv");
+}
+
+pub fn test_vwop_vv() {
+    test_vw_addu_vv();
+    test_vw_add_vv();
+    test_vw_mulu_vv();
+    test_vw_mul_vv();
+    test_vw_mulsu_vv();
+    test_vw_subu_vv();
+    test_vw_sub_vv();
 }

--- a/cases/src/vwop_vx_cases.rs
+++ b/cases/src/vwop_vx_cases.rs
@@ -2,9 +2,8 @@ use core::{arch::asm, convert::TryInto};
 use eint::{Eint, E256, E512};
 use rvv_asm::rvv_asm;
 use rvv_testcases::{
-    intrinsic::vwop_vx,
-    misc::{avl_iterator, conver_to_i512},
-    runner::{run_vop_vx, WideningCategory},
+    misc::conver_to_i512,
+    runner::{run_template_w_vx, MaskType},
 };
 
 fn expected_op_addu(lhs: &[u8], rhs: u64, result: &mut [u8]) {
@@ -27,21 +26,22 @@ fn expected_op_addu(lhs: &[u8], rhs: u64, result: &mut [u8]) {
         }
     }
 }
-fn test_vwaddu_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", "vwaddu.vx v24, v8, t0", in (reg) x);
-        });
+fn test_vwaddu_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vwaddu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vwaddu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_addu,
-        op,
-        WideningCategory::VdOnly,
-        "vwaddu.vx",
-    );
+    run_template_w_vx(expected_op_addu, op, true, "vwaddu.vx");
 }
 
 fn expected_op_add(lhs: &[u8], rhs: u64, result: &mut [u8]) {
@@ -64,21 +64,22 @@ fn expected_op_add(lhs: &[u8], rhs: u64, result: &mut [u8]) {
         }
     }
 }
-fn test_vwadd_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", "vwadd.vx v24, v8, t0", in (reg) x);
-        });
+fn test_vwadd_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vwadd.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vwadd.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_add,
-        op,
-        WideningCategory::VdOnly,
-        "vwadd.vx",
-    );
+    run_template_w_vx(expected_op_add, op, true, "vwadd.vx");
 }
 
 fn expected_op_subu(lhs: &[u8], rhs: u64, result: &mut [u8]) {
@@ -101,21 +102,22 @@ fn expected_op_subu(lhs: &[u8], rhs: u64, result: &mut [u8]) {
         }
     }
 }
-fn test_vwsubu_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", "vwsubu.vx v24, v8, t0", in (reg) x);
-        });
+fn test_vwsubu_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vwsubu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vwsubu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_subu,
-        op,
-        WideningCategory::VdOnly,
-        "vwsubu.vx",
-    );
+    run_template_w_vx(expected_op_subu, op, true, "vwsubu.vx");
 }
 
 fn expected_op_sub(lhs: &[u8], rhs: u64, result: &mut [u8]) {
@@ -138,21 +140,22 @@ fn expected_op_sub(lhs: &[u8], rhs: u64, result: &mut [u8]) {
         }
     }
 }
-fn test_vwsub_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", "vwsub.vx v24, v8, t0", in (reg) x);
-        });
+fn test_vwsub_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vwsub.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vwsub.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_sub,
-        op,
-        WideningCategory::VdOnly,
-        "vwsub.vx",
-    );
+    run_template_w_vx(expected_op_sub, op, true, "vwsub.vx");
 }
 
 fn expected_op_mulu(lhs: &[u8], rhs: u64, result: &mut [u8]) {
@@ -175,21 +178,22 @@ fn expected_op_mulu(lhs: &[u8], rhs: u64, result: &mut [u8]) {
         }
     }
 }
-fn test_vwmulu_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", "vwmulu.vx v24, v8, t0", in (reg) x);
-        });
+fn test_vwmulu_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vwmulu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vwmulu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_mulu,
-        op,
-        WideningCategory::VdOnly,
-        "vwmulu.vx",
-    );
+    run_template_w_vx(expected_op_mulu, op, true, "vwmulu.vx");
 }
 
 fn expected_op_mul(lhs: &[u8], rhs: u64, result: &mut [u8]) {
@@ -212,21 +216,22 @@ fn expected_op_mul(lhs: &[u8], rhs: u64, result: &mut [u8]) {
         }
     }
 }
-fn test_vwmul_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", "vwmul.vx v24, v8, t0", in (reg) x);
-        });
+fn test_vwmul_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vwmul.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vwmul.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_mul,
-        op,
-        WideningCategory::VdOnly,
-        "vwmul.vx",
-    );
+    run_template_w_vx(expected_op_mul, op, true, "vwmul.vx");
 }
 
 fn expected_op_mulsu(lhs: &[u8], rhs: u64, result: &mut [u8]) {
@@ -249,35 +254,30 @@ fn expected_op_mulsu(lhs: &[u8], rhs: u64, result: &mut [u8]) {
         }
     }
 }
-fn test_vwmulsu_vx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_vx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", "vwmulsu.vx v24, v8, t0", in (reg) x);
-        });
-    }
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_mulsu,
-        op,
-        WideningCategory::VdOnly,
-        "vwmulsu.vx",
-    );
-}
-
-pub fn test_vwop_vx() {
-    for sew in [64, 256] {
-        for lmul in [-2, 1, 2] {
-            for avl in avl_iterator(sew, 4) {
-                test_vwaddu_vx(sew, lmul, avl);
-                test_vwadd_vx(sew, lmul, avl);
-                test_vwsubu_vx(sew, lmul, avl);
-                test_vwsub_vx(sew, lmul, avl);
-                test_vwmulu_vx(sew, lmul, avl);
-                test_vwmul_vx(sew, lmul, avl);
-                test_vwmulsu_vx(sew, lmul, avl);
+fn test_vwmulsu_vx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vwmulsu.vx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vwmulsu.vx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
             }
         }
     }
+    run_template_w_vx(expected_op_mulsu, op, true, "vwmulsu.vx");
+}
+
+pub fn test_vwop_vx() {
+    test_vwaddu_vx();
+    test_vwadd_vx();
+    test_vwsubu_vx();
+    test_vwsub_vx();
+    test_vwmulu_vx();
+    test_vwmul_vx();
+    test_vwmulsu_vx();
 }

--- a/cases/src/vwop_wv_cases.rs
+++ b/cases/src/vwop_wv_cases.rs
@@ -1,11 +1,9 @@
-use alloc::boxed::Box;
 use core::{arch::asm, convert::TryInto};
 use eint::{Eint, E256, E512};
 use rvv_asm::rvv_asm;
 use rvv_testcases::{
-    intrinsic::vwop_wv,
-    misc::{avl_iterator, conver_to_i512},
-    runner::{run_vop_vv, ExpectedOp, WideningCategory},
+    misc::conver_to_i512,
+    runner::{run_template_w_wv, MaskType},
 };
 
 fn expected_op_addu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -33,21 +31,21 @@ fn expected_op_addu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vw_addu_wv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_wv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vwaddu.wv v24, v8, v16");
-        });
+fn test_vw_addu_wv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vwaddu.wv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vwaddu.wv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_addu)),
-        op,
-        WideningCategory::VdVs2,
-        "vwaddu.wv",
-    );
+    run_template_w_wv(expected_op_addu, op, true, "vwaddu.wv");
 }
 
 fn expected_op_add(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -75,21 +73,21 @@ fn expected_op_add(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vw_add_wv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_wv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vwadd.wv v24, v8, v16");
-        });
+fn test_vw_add_wv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vwadd.wv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vwadd.wv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_add)),
-        op,
-        WideningCategory::VdVs2,
-        "vwadd.wv",
-    );
+    run_template_w_wv(expected_op_add, op, true, "vwadd.wv");
 }
 
 fn expected_op_subu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -117,21 +115,21 @@ fn expected_op_subu(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vw_subu_wv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_wv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vwsubu.wv v24, v8, v16");
-        });
+fn test_vw_subu_wv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vwsubu.wv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vwsubu.wv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_subu)),
-        op,
-        WideningCategory::VdVs2,
-        "vwsubu.wv",
-    );
+    run_template_w_wv(expected_op_subu, op, true, "vwsubu.wv");
 }
 
 fn expected_op_sub(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
@@ -159,33 +157,27 @@ fn expected_op_sub(lhs: &[u8], rhs: &[u8], result: &mut [u8]) {
         }
     }
 }
-fn test_vw_sub_wv(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], rhs: &[u8], result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_wv(lhs, rhs, result, sew, avl, lmul, || unsafe {
-            rvv_asm!("vwsub.wv v24, v8, v16");
-        });
-    }
-    run_vop_vv(
-        sew,
-        lmul,
-        avl,
-        ExpectedOp::Normal(Box::new(expected_op_sub)),
-        op,
-        WideningCategory::VdVs2,
-        "vwsub.wv",
-    );
-}
-
-pub fn test_vwop_wv() {
-    for sew in [64, 256] {
-        for lmul in [-4, -2, 1, 2, 4] {
-            for avl in avl_iterator(sew, 4) {
-                test_vw_addu_wv(sew, lmul, avl);
-                test_vw_add_wv(sew, lmul, avl);
-
-                test_vw_subu_wv(sew, lmul, avl);
-                test_vw_sub_wv(sew, lmul, avl);
+fn test_vw_sub_wv() {
+    fn op(_: &[u8], _: &[u8], mask_type: MaskType) {
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("vwsub.wv v24, v8, v16, v0.t");
+                }
+                MaskType::Disable => {
+                    rvv_asm!("vwsub.wv v24, v8, v16");
+                }
+                _ => panic!("Abort"),
             }
         }
     }
+    run_template_w_wv(expected_op_sub, op, true, "vwsub.wv");
+}
+
+pub fn test_vwop_wv() {
+    test_vw_addu_wv();
+    test_vw_add_wv();
+
+    test_vw_subu_wv();
+    test_vw_sub_wv();
 }

--- a/cases/src/vwop_wx_cases.rs
+++ b/cases/src/vwop_wx_cases.rs
@@ -1,11 +1,7 @@
 use core::{arch::asm, convert::TryInto};
 use eint::{Eint, E512};
 use rvv_asm::rvv_asm;
-use rvv_testcases::{
-    intrinsic::vwop_wx,
-    misc::avl_iterator,
-    runner::{run_vop_vx, WideningCategory},
-};
+use rvv_testcases::runner::{run_template_w_wx, MaskType};
 
 fn expected_op_addu(lhs: &[u8], rhs: u64, result: &mut [u8]) {
     assert_eq!(lhs.len(), result.len());
@@ -31,22 +27,22 @@ fn expected_op_addu(lhs: &[u8], rhs: u64, result: &mut [u8]) {
         }
     }
 }
-fn test_vw_addu_wx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_wx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", "vwaddu.wx v24, v8, t0", in (reg) x);
-        });
+fn test_vw_addu_wx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vwaddu.wx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vwaddu.wx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_addu,
-        op,
-        WideningCategory::VdVs2,
-        "vwaddu.wx",
-    );
+    run_template_w_wx(expected_op_addu, op, true, "vwaddu.wx");
 }
 
 fn expected_op_add(lhs: &[u8], rhs: u64, result: &mut [u8]) {
@@ -73,22 +69,22 @@ fn expected_op_add(lhs: &[u8], rhs: u64, result: &mut [u8]) {
         }
     }
 }
-fn test_vw_add_wx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_wx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", "vwadd.wx v24, v8, t0", in (reg) x);
-        });
+fn test_vw_add_wx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vwadd.wx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vwadd.wx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_add,
-        op,
-        WideningCategory::VdVs2,
-        "vwadd.wx",
-    );
+    run_template_w_wx(expected_op_add, op, true, "vwadd.wx");
 }
 
 fn expected_op_subu(lhs: &[u8], rhs: u64, result: &mut [u8]) {
@@ -115,22 +111,22 @@ fn expected_op_subu(lhs: &[u8], rhs: u64, result: &mut [u8]) {
         }
     }
 }
-fn test_vw_subu_wx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_wx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", "vwsubu.wx v24, v8, t0", in (reg) x);
-        });
+fn test_vw_subu_wx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vwsubu.wx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vwsubu.wx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
+            }
+        }
     }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_subu,
-        op,
-        WideningCategory::VdVs2,
-        "vwsubu.wx",
-    );
+    run_template_w_wx(expected_op_subu, op, true, "vwsubu.wx");
 }
 
 fn expected_op_sub(lhs: &[u8], rhs: u64, result: &mut [u8]) {
@@ -157,33 +153,27 @@ fn expected_op_sub(lhs: &[u8], rhs: u64, result: &mut [u8]) {
         }
     }
 }
-fn test_vw_sub_wx(sew: u64, lmul: i64, avl: u64) {
-    fn op(lhs: &[u8], x: u64, result: &mut [u8], sew: u64, lmul: i64, avl: u64) {
-        vwop_wx(lhs, x, result, sew, avl, lmul, |x: u64| unsafe {
-            rvv_asm!("mv t0, {}", "vwsub.wx v24, v8, t0", in (reg) x);
-        });
-    }
-
-    run_vop_vx(
-        sew,
-        lmul,
-        avl,
-        expected_op_sub,
-        op,
-        WideningCategory::VdVs2,
-        "vwsub.wx",
-    );
-}
-
-pub fn test_vwop_wx() {
-    for sew in [64, 256] {
-        for lmul in [-4, -2, 1, 2, 4] {
-            for avl in avl_iterator(sew, 4) {
-                test_vw_addu_wx(sew, lmul, avl);
-                test_vw_add_wx(sew, lmul, avl);
-                test_vw_subu_wx(sew, lmul, avl);
-                test_vw_sub_wx(sew, lmul, avl);
+fn test_vw_sub_wx() {
+    fn op(_: &[u8], rhs: &[u8], mask_type: MaskType) {
+        let x = u64::from_le_bytes(rhs.try_into().unwrap());
+        unsafe {
+            match mask_type {
+                MaskType::Enable => {
+                    rvv_asm!("mv t0, {}", "vwsub.wx v24, v8, t0, v0.t", in (reg) x);
+                }
+                MaskType::Disable => {
+                    rvv_asm!("mv t0, {}", "vwsub.wx v24, v8, t0", in (reg) x);
+                }
+                _ => panic!("Abort"),
             }
         }
     }
+    run_template_w_wx(expected_op_sub, op, true, "vwsub.wx");
+}
+
+pub fn test_vwop_wx() {
+    test_vw_addu_wx();
+    test_vw_add_wx();
+    test_vw_subu_wx();
+    test_vw_sub_wx();
 }


### PR DESCRIPTION
Refactory and mask support.
The instructions use the same underlying function as much as possible, which is convenient to control the test scope.
And added some missing commands.